### PR TITLE
Clean golden tests before re-generating them.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,18 @@ export BUILD_HARNESS_EXTENSIONS_PATH ?= $(BUILD_HARNESS_PATH)/build-harness-exte
   jsonnet/diff                        Diff Jsonnet fils against expected golden 
   jsonnet/diff-help                   Help regarding Jsonnet diff
   jsonnet/gen-golden                  Generate expected golden files from Jsonnet
+  jsonnet/install                     Install packages from jsonnetfile.json with jsonnet-bundler
+  jsonnet/rm-golden                   Remove golden files from Jsonnet
   jsonnet/test                        Run Jsonnet tests
+  jsonnet/update                      Update packages from jsonnetfile.json with jsonnet-bundler
   kind/create                         Start KinD local cluster
   kind/delete                         Delete KinD local cluster
-  kind/up                             Install jsonnetfile.json with jsonnet-bundler
-  opa/clone-policy                    Git clone policies (requires OPA_POLICIES_REPO argument)
+  kubecfg/validate                    Validate manifests
+  kubeval/validate                    Validate manifests
+  opa/clone-policy                    Git clone policies (requires OPA_POLICY_REPO argument)
   opa/conftest                        Validate manifests
   pluto/validate                      Validate manifests
   tanka/fmt                           Format Jsonnet files with tanka
   tanka/generate                      Generate manifests using tanka
   tanka/to-kustomize                  Generate kustomization for tanka-generated manifests
-  ```
+```

--- a/modules/jsonnet/Makefile
+++ b/modules/jsonnet/Makefile
@@ -37,7 +37,7 @@ jsonnet/rm-golden:
 
 .PHONY: jsonnet/gen-golden
 ## Generate expected golden files from Jsonnet
-jsonnet/gen-golden: jsonnet/remove-golden $(JSONNET_PHONY_GOLDEN)
+jsonnet/gen-golden: jsonnet/rm-golden $(JSONNET_PHONY_GOLDEN)
 
 .PHONY: jsonnet/diff-help
 ## Help regarding Jsonnet diff

--- a/modules/jsonnet/Makefile
+++ b/modules/jsonnet/Makefile
@@ -34,7 +34,6 @@ jsonnet/diff: jsonnet/diff-help $(JSONNET_PHONY_DIFF)
 jsonnet/rm-golden:
 	rm -f $(JSONNET_GOLDEN_FILES)
 
-
 .PHONY: jsonnet/gen-golden
 ## Generate expected golden files from Jsonnet
 jsonnet/gen-golden: jsonnet/rm-golden $(JSONNET_PHONY_GOLDEN)

--- a/modules/jsonnet/Makefile
+++ b/modules/jsonnet/Makefile
@@ -1,31 +1,45 @@
 ## Jsonnet helpers
 JSONNET_ARGS=-J ./lib -J ./vendor -J .
 JSONNET_TEST_FILES=$(wildcard ./*/tests/test.jsonnet)
+JSONNET_GOLDEN_FILES=$(wildcard ./*/tests/test-golden.json)
 JSONNET_PHONY_GOLDEN=$(patsubst %.jsonnet,%-golden.json,$(JSONNET_TEST_FILES))
 JSONNET_PHONY_DIFF=$(patsubst %.jsonnet,%.diff,$(JSONNET_TEST_FILES))
 
-## Install jsonnetfile.json with jsonnet-bundler
+.PHONY: jsonnet/install
+## Install packages from jsonnetfile.json with jsonnet-bundler
 jsonnet/install:
 	jb install
 
+.PHONY: jsonnet/update
+## Update packages from jsonnetfile.json with jsonnet-bundler
+jsonnet/update:
+	jb update
+
+.PHONY: jsonnet/test
 ## Run Jsonnet tests
 jsonnet/test: jsonnet/install jsonnet/diff
 
+.PHONY: jsonnet/diff
 ## Diff Jsonnet fils against expected golden 
 jsonnet/diff: jsonnet/diff-help $(JSONNET_PHONY_DIFF)
 
 %.diff: %.jsonnet
 	diff -u $(*)-golden.json <(jsonnet $(JSONNET_ARGS) $(<))
 
-%.parse: %.jsonnet
-	jsonnet $(JSONNET_ARGS) $(<) > /dev/null
-
 %-golden.json: %.jsonnet
 	jsonnet $(JSONNET_ARGS) $(<) > $(@)
 
-## Generate expected golden files from Jsonnet
-jsonnet/gen-golden: $(JSONNET_PHONY_GOLDEN)
+.PHONY: jsonnet/rm-golden
+## Remove golden files from Jsonnet
+jsonnet/rm-golden:
+	rm -f $(JSONNET_GOLDEN_FILES)
 
+
+.PHONY: jsonnet/gen-golden
+## Generate expected golden files from Jsonnet
+jsonnet/gen-golden: jsonnet/remove-golden $(JSONNET_PHONY_GOLDEN)
+
+.PHONY: jsonnet/diff-help
 ## Help regarding Jsonnet diff
 jsonnet/diff-help:
 	@echo "NOTE: if the 'jsonnet/diff' target fails, review output and run:"


### PR DESCRIPTION
Without this it's pretty difficult to re-generate golden tests, for example when a dep. changes.

This just provides a `jsonnet/rm-golden` target that can be used to delete old golden tests, so that `jsonnet/gen-golden` re-creates all tests.

Also removed old `parse` target (not used) and added `PHONY`