### PR TITLE
Added required comment for `kind/create`

### DIFF
--- a/modules/kind/Makefile
+++ b/modules/kind/Makefile
@@ -1,6 +1,7 @@
 ## KinD Helpers
 export KIND_INSTALL_DOCKER_REGISTRY?=1
 
+## Create KinD local cluster
 kind/create:
 	@@${BUILD_HARNESS_EXTENSIONS_PATH}/bin/kind.sh create
 


### PR DESCRIPTION
This enables `kind/create` to show up when we run `make help` in build-harness.