### PR TITLE
When in a for loop the error won't propagate

### DIFF
--- a/modules/jsonnet/Makefile
+++ b/modules/jsonnet/Makefile
@@ -10,20 +10,24 @@ JSONNETFILE_DIRS=$(dir $(wildcard ./environments/*/jsonnetfile.json) $(wildcard 
 ## Install packages from jsonnetfile.json with jsonnet-bundler
 jsonnet/install:
 	@for dir in $(JSONNETFILE_DIRS); do \
+		set -e; \
 		pushd $$dir >/dev/null; \
 		echo "Running JB install in $$dir"; \
 		jb install; \
 		popd >/dev/null; \
+		set +e; \
 	done
 
 .PHONY: jsonnet/update
 ## Update packages from jsonnetfile.json with jsonnet-bundler
 jsonnet/update:
 	@for dir in $(JSONNETFILE_DIRS); do \
+		set -e; \
 		pushd $$dir >/dev/null; \
 		echo "Running JB update in $$dir"; \
 		jb update; \
 		popd >/dev/null; \
+		set +e; \
 	done
 
 .PHONY: jsonnet/test


### PR DESCRIPTION
causing the pipeline jobs to succed on gitlab even though they actually failed

https://gitlab.com/mintel/satoshi/kubernetes/jsonnet/sre/kube-monitoring-jsonnet/-/jobs/877225097
