### PR TITLE
tanka: Don't render local env by default

### DIFF
--- a/modules/tanka/generate.sh
+++ b/modules/tanka/generate.sh
@@ -1,45 +1,40 @@
 #!/bin/bash
 
 set -e
+shopt -s extglob; # Need extented glob patterns to exclude local env by default.
 
 APP="$1"
-ENV="$2"
+if [[ -z "$APP" ]]; then
+  APP="*"
+fi
 
-TANKA_EXPORT_FMT="{{.apiVersion}}.{{.kind}}-{{ if.metadata.namespace}}{{.metadata.namespace }}-{{end}}{{.metadata.name }}"
-TANKA_REPO_DIR=$(pwd)
-ALL_ENVS=$(find environments -type f -name main.jsonnet -printf '%h\n' | grep "$APP" | grep "$ENV")
+ENV="$2"
+if [[ -z "$ENV" ]]; then
+  # Don't render the local env unless explicitly specified.
+  ENV="!(local)"
+fi
+
+TANKA_DEFAULT_EXPORT_FMT="{{.apiVersion}}.{{.kind}}-{{ if.metadata.namespace}}{{.metadata.namespace }}-{{end}}{{.metadata.name }}"
+TANKA_EXPORT_FMT=${TANKA_EXPORT_FMT:-$TANKA_DEFAULT_EXPORT_FMT}
 
 echo
 echo "Generating rendered manifests in ./rendered"
 echo "Run 'make jsonnet/[install|update]' beforehand if you require vendor package installation"
 echo
 
-mkdir -p "$(pwd)/rendered/"
-touch "$(pwd)/rendered/.gitkeep"
+mkdir -p "rendered"
+touch "rendered/.gitkeep"
 
 # Generate the list of directories to render
 
-if [[ -n "$APP" ]]; then
-  dirs=$(echo "$ALL_ENVS" | grep "$APP")
-  if [[ -n "$ENV" ]]; then
-    dirs=$(echo "$dirs" | grep "$ENV")
-  fi
-else
-  if [[ -n "$ENV" ]]; then
-    dirs=$(echo "$ALL_ENVS" | grep "$ENV")
-  else
-    dirs="$ALL_ENVS"
-  fi
-fi
-
-for env_path in $dirs; do
-  echo "Generating $env_path"
-  mkdir -p "./rendered/$env_path"
-  pushd "./rendered/$env_path" > /dev/null || exit 1
-  touch kustomization.yaml
-  yq -i eval 'del(.resources)' kustomization.yaml
-  rm -rf ./manifests/*.yaml
-  tk export --format="$TANKA_EXPORT_FMT" "$TANKA_REPO_DIR/$env_path" ./manifests > /dev/null
-  kustomize edit add resource ./manifests/*.yaml
-  popd > /dev/null || exit 1
+for main_file in environments/$APP/$ENV/main.jsonnet; do
+  env_dir="$(dirname "$main_file")"
+  rendered_dir="rendered/$env_dir"
+  echo "Generating $rendered_dir"
+  mkdir -p "$rendered_dir"
+  touch "$rendered_dir/kustomization.yaml"
+  yq -i eval 'del(.resources)' "$rendered_dir/kustomization.yaml"
+  rm -rf "$rendered_dir/manifests"
+  tk export --format="$TANKA_EXPORT_FMT" "$env_dir" "$rendered_dir/manifests" > /dev/null
+  (cd "$rendered_dir" && kustomize edit add resource ./manifests/*.yaml)
 done


### PR DESCRIPTION
When testing jsonnet code locally we typically us `tk apply`, so there's no need to render and commit the local versions of Kubernetes manifests.