### PR TITLE
Skip satoshi package dep-checks when running in CI

### DIFF
--- a/modules/satoshi/Makefile
+++ b/modules/satoshi/Makefile
@@ -11,8 +11,8 @@ REQUIRED_SATOSHI_BINS := conftest helm jb kubectl kustomize opa pluto tk yq
 ## Check dependencies for Satoshi
 satoshi/check-deps: satoshi/check-asdf-dep
 	$(foreach bin,$(REQUIRED_SATOSHI_BINS),\
-		$(if $(shell command -v $(bin) 2> /dev/null),,$(error $(S_RED)[satoshi/check-deps] Please install `$(bin)` using `make asdf/install`)))
+		$(if $(shell command -v $(bin) 2> /dev/null),,$(error $(S_RED)[satoshi/check-deps] Please install `$(bin)` using `make asdf/install`$(S_RST))))
 
 ## Check dependencies (installer) for Satoshi
 satoshi/check-asdf-dep:
-	$(if $(shell command -v asdf 2> /dev/null),,$(error $(S_RED)[satoshi/check-asdf-dep] Please install `asdf` (https://github.com/asdf-vm/asdf)))
+	$(if $(shell command -v asdf 2> /dev/null),,$(error $(S_RED)[satoshi/check-asdf-dep] Please install `asdf` (https://github.com/asdf-vm/asdf)$(S_RST)))

--- a/modules/satoshi/Makefile
+++ b/modules/satoshi/Makefile
@@ -4,10 +4,12 @@ S_YLW := $(shell tput -Txterm setaf 3)
 S_RST := $(shell tput -Txterm sgr0)
 S_BLD := $(shell tput bold)
 
-REQUIRED_SATOSHI_BINS := conftest helm jb kubectl kustomize opa pluto tk yq
+REQUIRED_SATOSHI_BINS := conftest helm jb jsonnet kubectl kustomize opa pluto tk yq
 
 .PHONY: satoshi/check-deps satoshi/check-asdf-dep
 
+# Skip checks if running in CI for now (binaries not installed by asdf)
+ifndef CI
 ## Check dependencies for Satoshi
 satoshi/check-deps: satoshi/check-asdf-dep
 	$(foreach bin,$(REQUIRED_SATOSHI_BINS),\
@@ -16,3 +18,4 @@ satoshi/check-deps: satoshi/check-asdf-dep
 ## Check dependencies (installer) for Satoshi
 satoshi/check-asdf-dep:
 	$(if $(shell command -v asdf 2> /dev/null),,$(error $(S_RED)[satoshi/check-asdf-dep] Please install `asdf` (https://github.com/asdf-vm/asdf)$(S_RST)))
+endif


### PR DESCRIPTION
We use docker at this point not ASDF (plus not all binaries will be required in CI).

