### PR TITLE
Hide errors from trying to find k8s manifests

### DIFF
--- a/modules/kubecfg/Makefile
+++ b/modules/kubecfg/Makefile
@@ -1,5 +1,5 @@
 ## Kubecfg helpers
-MANIFEST_DIRS:=$(shell find rendered/ -type d -name manifests)
+MANIFEST_DIRS:=$(shell find rendered/ -type d -name manifests 2>/dev/null)
 
 .PHONY: kubecfg/validate
 

--- a/modules/opa/Makefile
+++ b/modules/opa/Makefile
@@ -2,7 +2,7 @@
 OPA_POLICY_BRANCH?=main
 OPA_POLICY_DIR=/tmp/opa-policy
 OPA_POLICY_SUBDIR=opa/kubernetes
-MANIFEST_DIRS:=$(shell find rendered/ -type d -name manifests)
+MANIFEST_DIRS:=$(shell find rendered/ -type d -name manifests 2>/dev/null)
 
 .PHONY: opa/check-env opa/clone-policy opa/conftest
 

--- a/modules/pluto/Makefile
+++ b/modules/pluto/Makefile
@@ -1,7 +1,7 @@
 ## Pluto helpers
 PLUTO_K8S_VERSION?=v1.19.0
 PLUTO_VERBOSITY?=0
-MANIFEST_DIRS:=$(shell find rendered/ -type d -name manifests)
+MANIFEST_DIRS:=$(shell find rendered/ -type d -name manifests 2>/dev/null)
 
 .PHONY: pluto/validate
 


### PR DESCRIPTION
If a project has no `rendered` folder, these lines generate an error
message like:

```
    find: ‘rendered/’: No such file or directory
```

Ignore error output from these commands instead.