### PR TITLE
Prefer go-jsonnet to jsonnet

### DIFF
--- a/modules/asdf/Makefile
+++ b/modules/asdf/Makefile
@@ -7,4 +7,4 @@ ASDF_REPO_DIR=$(shell pwd)
 ## Installing required tools
 asdf/install:
 	test -s $(ASDF_ROOT) || git clone https://github.com/asdf-vm/asdf.git $(ASDF_ROOT) && source $(ASDF_ROOT)/asdf.sh ;\
-	cat ${ASDF_REPO_DIR}/.tool-versions | grep -v "#" | cut -d' ' -f1 | xargs -I_pkg -- sh -c 'asdf plugin add _pkg ; asdf install _pkg'
+	cat ${ASDF_REPO_DIR}/.tool-versions | grep -E "^#asdf:" | cut -d':' -f2- | tr '\n' '\0' | xargs -0 -n1 -Icmd -- sh -c 'asdf cmd'

--- a/modules/satoshi/tool-versions
+++ b/modules/satoshi/tool-versions
@@ -1,22 +1,28 @@
 #
 # DO NOT OVERRIDE THIS FILE. AUTO-GENERATED FROM 'make satoshi/update-tools'
 #
-conftest v0.28.1
-helm 3.7.2
-jb 0.4.0
-k3d 5.2.2
-kubectl 1.21.2
-kubeval v0.16.1
-kustomize 4.4.0
-opa 0.35.0
-pluto 5.2.4
-tanka 0.19.0
-yq v4.12.0
 
-# The default go-jsonnet plugin requires Go to be installed because it compiles
-# the binary from scratch. If you would prefer not to install Go, there is an
-# alternative plugin that downloads a pre-built binary from GitHub:
-#
-# $ asdf plugin remove go-jsonnet
-# $ asdf plugin add go-jsonnet https://github.com/sirikon/asdf-go-jsonnet.git
+#asdf:plugin add conftest
+conftest v0.28.1
+#asdf:plugin add go-jsonnet https://github.com/sirikon/asdf-go-jsonnet.git
 go-jsonnet 0.18.0
+#asdf:plugin add helm
+helm 3.7.2
+#asdf:plugin add jb
+jb 0.4.0
+#asdf:plugin add k3d
+k3d 5.2.2
+#asdf:plugin add kubectl
+kubectl 1.21.2
+#asdf:plugin add kubeval
+kubeval v0.16.1
+#asdf:plugin add kustomize
+kustomize 4.4.0
+#asdf:plugin add opa
+opa 0.35.0
+#asdf:plugin add pluto
+pluto 5.2.4
+#asdf:plugin add tanka
+tanka 0.19.0
+#asdf:plugin add yq
+yq v4.12.0

--- a/modules/satoshi/tool-versions
+++ b/modules/satoshi/tool-versions
@@ -4,7 +4,6 @@
 conftest v0.28.1
 helm 3.7.2
 jb 0.4.0
-jsonnet 0.18.0
 k3d 5.2.2
 kubectl 1.21.2
 kubeval v0.16.1
@@ -13,3 +12,11 @@ opa 0.35.0
 pluto 5.2.4
 tanka 0.19.0
 yq v4.12.0
+
+# The default go-jsonnet plugin requires Go to be installed because it compiles
+# the binary from scratch. If you would prefer not to install Go, there is an
+# alternative plugin that downloads a pre-built binary from GitHub:
+#
+# $ asdf plugin remove go-jsonnet
+# $ asdf plugin add go-jsonnet https://github.com/sirikon/asdf-go-jsonnet.git
+go-jsonnet 0.18.0


### PR DESCRIPTION
Google has a newer implementation of jsonnet, written (mostly) in Go:

https://github.com/google/go-jsonnet

It's compatible with the original jsonnet, has a few additional
features, and is "orders of magnitude faster [in some cases]."

This PR also changes how asdf plugins are added; the `asdf/install` target will now look for comments formatted like this:
```
#asdf:plugin add go-jsonnet https://github.com/sirikon/asdf-go-jsonnet.git
```
Everything after `#asdf:` is called as an asdf subcommand.