### PR TITLE
Fix asdf install

### DIFF
--- a/modules/asdf/Makefile
+++ b/modules/asdf/Makefile
@@ -7,4 +7,5 @@ ASDF_REPO_DIR=$(shell pwd)
 ## Installing required tools
 asdf/install:
 	test -s $(ASDF_ROOT) || git clone https://github.com/asdf-vm/asdf.git $(ASDF_ROOT) && source $(ASDF_ROOT)/asdf.sh ;\
-	cat ${ASDF_REPO_DIR}/.tool-versions | grep -E "^#asdf:" | cut -d':' -f2- | tr '\n' '\0' | xargs -0 -n1 -Icmd -- sh -c 'asdf cmd'
+	grep -E "^#asdf:" '${ASDF_REPO_DIR}/.tool-versions' | cut -d':' -f2- | tr '\n' '\0' | xargs -0 -n1 -Icmd -- sh -c 'asdf cmd' || true;\
+	asdf install


### PR DESCRIPTION
1. It doesn't actually do the install.
2. Need to ignore errors from `asdf plugin add` when the plugin has already been added.