### PR TITLE
Fix yq tool version

### DIFF
--- a/modules/satoshi/tool-versions
+++ b/modules/satoshi/tool-versions
@@ -25,4 +25,4 @@ pluto 5.2.4
 #asdf:plugin add tanka
 tanka 0.19.0
 #asdf:plugin add yq
-yq v4.12.0
+yq 4.12.0


### PR DESCRIPTION
There is a bug in the asdf plugin for yq where recent versions of yq
won't install if the version number is prefixed with a `v`. (It has to
do with the yq repo changing how they format release download URLs in
GitHub.)

The error only occurs the first time you install that version yq.
Thereafter a version prefixed with `v` will work because asdf detects
the version as already being installed.