### PR TITLE
Run jsonnet/install before tanka/generate

### DIFF
--- a/modules/tanka/Makefile
+++ b/modules/tanka/Makefile
@@ -12,5 +12,5 @@ tanka/fmt-test: satoshi/check-deps
 	make k8s/tanka/fmt-test
 
 ## Generate manifests using tanka
-tanka/generate: satoshi/check-deps
+tanka/generate: satoshi/check-deps jsonnet/install
 	make k8s/tanka/generate


### PR DESCRIPTION
It's all too easy to pull some changes to a `jsonnetfile.lock.json` file
and not realize to need to run `make jsonnet/install` to update your
local dependencies. And then you wonder why `make tanka/generate`
changed so many files.

This commit runs the `jsonnet/install` target as a dependency of the
`tanka/generate` target. If there are no dependencies to update, the
build time added is pretty small.