### PR TITLE
send tk env list errors to /dev/null

### DIFF
--- a/modules/k8s/tanka/generate.sh
+++ b/modules/k8s/tanka/generate.sh
@@ -38,7 +38,7 @@ if [ "$ENV" != "local" ]; then
   dirs=$(echo "$dirs" | grep -v local)
 fi
 for env_path in $dirs; do
-  cluster_envs=$(tk env list --names | grep "$env_path")
+  cluster_envs=$(tk env list --names 2>/dev/null | grep "$env_path")
   for cluster_env in $cluster_envs; do
     echo "Generating $cluster_env"
     mkdir -p "./rendered/$cluster_env"


### PR DESCRIPTION
Setting a deprecation trace message in the upstream libs-jsonnet repo results in a ton of trace messages from the `tk env list` command. We can send them to `/dev/null` and still be able to see them in the `tk export` output.