### PR TITLE
Filter Tanka Environments by label instead of by grep

### DIFF
--- a/modules/k8s/tanka/new-app.sh
+++ b/modules/k8s/tanka/new-app.sh
@@ -107,6 +107,10 @@ do
   kind: 'Environment',
   metadata: {
     name: 'environments/${APP_NAME}/${ENV}',
+    labels: {
+      app: '${APP_NAME}',
+      env: '${ENV}',
+    },
   },
   spec: {
     namespace: $.data._config.namespace,${API_SERVER}


### PR DESCRIPTION
This changes the Tanka manifest generation script to filter by 'app' and  'env' labels, which is more reliable than the current grep implementation. Grep is having some problems when envs have similar names e.g. `aws.dev` vs `aws.dev.bb1`.

I will use https://github.com/lindell/multi-gitter to open MRs to add labels to all the existing jsonnet repos.