### PR TITLE
Added grafana/develop prompt to ask for dashboards directory if not specified

### DIFF
--- a/modules/grafana/Makefile
+++ b/modules/grafana/Makefile
@@ -1,21 +1,23 @@
 # You might want to set these when you run make
 GRAFANA_ADMIN_PASSWORD ?= admin
-LOCAL_DASHBOARD_DIRECTORY ?= dashboards
+LOCAL_DASHBOARD_DIRECTORY ?= $(shell ${BUILD_HARNESS_EXTENSIONS_PATH}/modules/grafana/scripts/local_dashboard_directory_prompt.sh)
 BUILD_HARNESS_EXTENSIONS_PRIVATE_BRANCH ?= main
 
-# You should leave these as the default values
+# Generally no reason to change these defaults, but values don't matter as long as they're different from eachother
 GRAFANA_LOCAL_DOCKER_NAME = grafana_local
 GRAFANA_SYNC_DOCKER_NAME = grafana_sync
+
+# Don't change these, unless you understand how they're used in the scripts below and accept the repurcussions
 CONTAINER_DASHBOARD_DIRECTORY = /app/dashboards
 TMP_GITLAB_REPO_DIRECTORY = /tmp/build-harness-extensions-private
 
 .PHONY: grafana/develop
 # Start up a local grafana instance with live datasources, and sync to dashboards on your local disk. Only for mintel internal access, try grafana/develop-oss for general use.
-grafana/develop: grafana/setup-local-grafana-mintel grafana/setup-grafana-syncer grafana/cleanup
+grafana/develop: grafana/cleanup grafana/setup-local-grafana-mintel grafana/setup-grafana-syncer
 
 .PHONY: grafana/develop-oss
 # Start up a local grafana instance with no datasources configured, and sync to dashboards on your local disk
-grafana/develop-oss: grafana/setup-local-grafana-oss grafana/setup-grafana-syncer grafana/cleanup
+grafana/develop-oss: grafana/cleanup grafana/setup-local-grafana-oss grafana/setup-grafana-syncer
 
 grafana/private:
 	@git clone git@gitlab.com:mintel/satoshi/tools/build-harness-extensions-private.git -b ${BUILD_HARNESS_EXTENSIONS_PRIVATE_BRANCH} ${TMP_GITLAB_REPO_DIRECTORY}
@@ -29,9 +31,11 @@ grafana/setup-local-grafana-oss:
 
 grafana/setup-grafana-syncer:
 # Give the grafana instance time to start up before changing the admin password in order to avoid errors
+	@echo "Starting grafana on localhost:3000 ..."
 	@sleep 3s
 	@docker exec -it ${GRAFANA_LOCAL_DOCKER_NAME} grafana-cli --homepath "/usr/share/grafana" admin reset-admin-password ${GRAFANA_ADMIN_PASSWORD}
 	@docker run --rm -it --mount type=bind,source=$$PWD/${LOCAL_DASHBOARD_DIRECTORY},target=${CONTAINER_DASHBOARD_DIRECTORY}/LocalDev --network="host" --name ${GRAFANA_SYNC_DOCKER_NAME} mintel/grafana-local-sync:latest -user admin -pass ${GRAFANA_ADMIN_PASSWORD} -dir ${CONTAINER_DASHBOARD_DIRECTORY}
+	@$(MAKE) grafana/cleanup
 
 .PHONY: grafana/cleanup
 # Kill any docker containers associated with grafana/develop, and remove anything added to /tmp
@@ -42,3 +46,4 @@ grafana/cleanup:
 	@docker kill ${GRAFANA_SYNC_DOCKER_NAME} || true
 	@echo "Removing ${TMP_GITLAB_REPO_DIRECTORY}..."
 	@rm -rf ${TMP_GITLAB_REPO_DIRECTORY}
+	@echo "Cleanup successful."

--- a/modules/grafana/scripts/local_dashboard_directory_prompt.sh
+++ b/modules/grafana/scripts/local_dashboard_directory_prompt.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Prompts user for the relative path to dashboards directory.
+# To avoid this prompt, set LOCAL_DASHBOARD_DIRECTORY when you run make.
+shopt -s globstar
+PS3="Enter number of selection: "
+select dir in **/dashboards/ "Other (enter manually)"; do
+    if [[ $dir == "Other (enter manually)" ]]
+    then
+        read -erp "Enter relative path to dashboards directory: " dir
+    fi
+    echo -n "$dir"
+    break
+done


### PR DESCRIPTION
`make grafana/develop` now prompts the user for the relative path to the dashboards directory if the `LOCAL_DASHBOARD_DIRECTORY` env variable is not explicitly set