### PR TITLE
Replace git.io URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ As an example, you could `git-submodule` this into your repo (into the `build-ha
 
 ```sh
 export HELP_FILTER ?= git/submodules-update|jsonnet|k8s|opa
--include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+-include $(shell curl -sSL -o .build-harness "https://raw.githubusercontent.com/cloudposse/build-harness/HEAD/templates/Makefile.build-harness"; echo .build-harness)
 export BUILD_HARNESS_PATH ?= $(shell 'pwd')
 export BUILD_HARNESS_EXTENSIONS_PATH ?= $(BUILD_HARNESS_PATH)/build-harness-extensions
 ```

--- a/modules/satoshi/k8s-makefile.template
+++ b/modules/satoshi/k8s-makefile.template
@@ -2,7 +2,7 @@
 # DO NOT OVERRIDE THIS FILE. AUTO-GENERATED FROM 'make satoshi/update-makefile'
 #
 export HELP_FILTER ?= asdf|jsonnet|opa|pluto|satoshi|k8s
--include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+-include $(shell curl -sSL -o .build-harness "https://raw.githubusercontent.com/cloudposse/build-harness/HEAD/templates/Makefile.build-harness"; echo .build-harness)
 export BUILD_HARNESS_PATH ?= $(shell 'pwd')
 export BUILD_HARNESS_EXTENSIONS_PATH ?= $(BUILD_HARNESS_PATH)/build-harness-extensions
 

--- a/modules/satoshi/tf-makefile.template
+++ b/modules/satoshi/tf-makefile.template
@@ -2,7 +2,7 @@
 # DO NOT OVERRIDE THIS FILE. AUTO-GENERATED FROM 'make satoshi/update-makefile'
 #
 export HELP_FILTER ?= asdf|satoshi
--include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+-include $(shell curl -sSL -o .build-harness "https://raw.githubusercontent.com/cloudposse/build-harness/HEAD/templates/Makefile.build-harness"; echo .build-harness)
 export BUILD_HARNESS_PATH ?= $(shell 'pwd')
 export BUILD_HARNESS_EXTENSIONS_PATH ?= $(BUILD_HARNESS_PATH)/build-harness-extensions
 


### PR DESCRIPTION
https://github.blog/changelog/2022-04-25-git-io-deprecation/

Git.io now returns redirects which curl doesn't follow.