### PR TITLE
Fix tanka/generate args

### DIFF
--- a/modules/k8s/Makefile.tanka
+++ b/modules/k8s/Makefile.tanka
@@ -1,5 +1,12 @@
 ## Tanka helpers
 
+ifdef app
+GENERATE_ARGS+=--app $(app)
+endif
+ifdef env
+GENERATE_ARGS+=--env $(env)
+endif
+
 .PHONY: k8s/tanka/fmt k8s/tanka/fmt-test k8s/tanka/generate k8s/tanka/generate/% k8s/tanka/apply/% k8s/tanka/delete/% k8s/tanka/update-chart/% k8s/tanka/new-app/%
 
 ## Update Helm Chart
@@ -16,7 +23,7 @@ k8s/tanka/fmt-test: satoshi/check-deps
 
 ## Generate manifests using tanka
 k8s/tanka/generate: satoshi/check-deps
-	@@${BUILD_HARNESS_EXTENSIONS_PATH}/modules/k8s/tanka/generate.sh $(app) $(env)
+	@@${BUILD_HARNESS_EXTENSIONS_PATH}/modules/k8s/tanka/generate.sh $(GENERATE_ARGS)
 
 ## Generate manifests of specific app using tanka
 k8s/tanka/generate/%: satoshi/check-deps

--- a/modules/k8s/tanka/generate.sh
+++ b/modules/k8s/tanka/generate.sh
@@ -4,8 +4,38 @@ set -e -o pipefail
 
 LC_COLLATE=C
 
-APP="$1"
-ENV="$2"
+PARAMS=""
+while (( "$#" )); do
+  case "$1" in
+    -a|--app)
+      if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+        APP=$2
+        shift 2
+      else
+        echo "Error: Argument for $1 is missing" >&2
+        exit 1
+      fi
+      ;;
+    -e|--env)
+      if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+        ENV=$2
+        shift 2
+      else
+        echo "Error: Argument for $1 is missing" >&2
+        exit 1
+      fi
+      ;;
+    -*)
+      echo "Error: Unsupported flag $1" >&2
+      exit 1
+      ;;
+    *)
+      PARAMS="$PARAMS $1"
+      shift
+      ;;
+  esac
+done
+eval set -- "$PARAMS"
 
 SELECTOR=()
 if [ -n "$APP" ]; then


### PR DESCRIPTION
Fixes an issue where the args would sometimes be passed into the script in the wrong place if, for instance, `env` was defined but `app` was not.