### PR TITLE
Render manifests in parallel

### DIFF
--- a/modules/k8s/tanka/generate.sh
+++ b/modules/k8s/tanka/generate.sh
@@ -39,11 +39,11 @@ eval set -- "$PARAMS"
 
 SELECTOR=()
 if [ -n "$APP" ]; then
-	SELECTOR+=( "app=$APP" )
+	SELECTOR+=( "app in ($APP)" )
 fi
 
 if [ -n "$ENV" ]; then
-	SELECTOR+=( "env=$ENV" )
+	SELECTOR+=( "env in ($ENV)" )
 fi
 
 if [ "$ENV" != "local" ]; then

--- a/modules/k8s/tanka/generate.sh
+++ b/modules/k8s/tanka/generate.sh
@@ -50,7 +50,10 @@ if [ "$ENV" != "local" ]; then
 	SELECTOR+=( "env!=local" )
 fi
 
-TANKA_EXPORT_FMT='{{.apiVersion}}.{{.kind}}-{{ if.metadata.namespace }}{{ .metadata.namespace }}-{{end}}{{ if hasKey .metadata.annotations "app.mintel.com/altManifestFileSuffix" }}{{ get .metadata.annotations "app.mintel.com/altManifestFileSuffix" }}{{ else }}{{ .metadata.name }}{{ end }}'
+# Tanka uses a Bell character as a placeholder in for a path separator.
+# We can use a "replace" to hack it into the environment name.
+# See: https://github.com/grafana/tanka/blob/v0.22.1/pkg/tanka/export.go#L23
+TANKA_EXPORT_FMT='{{ env.metadata.name | replace "/" "\x07" }}/manifests/{{.apiVersion}}.{{.kind}}-{{ if.metadata.namespace }}{{ .metadata.namespace }}-{{end}}{{ if hasKey .metadata.annotations "app.mintel.com/altManifestFileSuffix" }}{{ get .metadata.annotations "app.mintel.com/altManifestFileSuffix" }}{{ else }}{{ .metadata.name }}{{ end }}'
 TANKA_REPO_DIR=$(pwd)
 
 join_arr() {
@@ -87,16 +90,17 @@ if [[ $rc != 0 ]]; then
 fi
 
 for env_name in $(tk env list environments --names -l "$(join_arr , "${SELECTOR[@]}")" 2>/dev/null); do
-	echo "Generating $env_name"
-	mkdir -p "./rendered/$env_name"
-	touch "./rendered/$env_name/kustomization.yaml"
-	yq -i eval 'del(.resources)' "./rendered/$env_name/kustomization.yaml"
-	rm -f "./rendered/$env_name/manifests/"*.yaml
-	rm -f "./rendered/$env_name/manifests/manifest.json"
-	env_path=$(find_jsonnet "$TANKA_REPO_DIR/$env_name")
-	tk export "./rendered/$env_name/manifests" "$env_path" --format="$TANKA_EXPORT_FMT" --name="$env_name" > /dev/null
-	pushd "./rendered/$env_name" > /dev/null || exit 1
+	mkdir -p "$TANKA_REPO_DIR/rendered/$env_name"
+	touch "$TANKA_REPO_DIR/rendered/$env_name/kustomization.yaml"
+	yq -i eval 'del(.resources)' "$TANKA_REPO_DIR/rendered/$env_name/kustomization.yaml"
+	rm -f "$TANKA_REPO_DIR/rendered/$env_name/manifests/"*.yaml
+done
+
+tk export "$TANKA_REPO_DIR/rendered/" "$TANKA_REPO_DIR/environments" -r -l "$(join_arr , "${SELECTOR[@]}")" --format="$TANKA_EXPORT_FMT" --merge
+find "$TANKA_REPO_DIR/rendered" -name "manifest.json" -delete
+
+for env_name in $(tk env list environments --names -l "$(join_arr , "${SELECTOR[@]}")" 2>/dev/null); do
+	pushd "$TANKA_REPO_DIR/rendered/$env_name" > /dev/null || exit 1
 	kustomize edit add resource ./manifests/*.yaml
 	popd > /dev/null || exit 1
-	echo
 done

--- a/modules/satoshi/k8s-tool-versions
+++ b/modules/satoshi/k8s-tool-versions
@@ -25,6 +25,6 @@ opa 0.35.0
 #asdf:plugin add pluto
 pluto 5.2.4
 #asdf:plugin add tanka
-tanka 0.21.0
+tanka 0.22.1
 #asdf:plugin add yq
 yq 4.12.0


### PR DESCRIPTION
Tanka can render multiple manifests in parallel. It's just a matter of
convincing it to generate files at the paths we want. That's what this
commit does.

Timings for rendering all of core-cluster-jsonnet:

- Before: 112.84 secs
- After: 38.02 seconds

Note: this change also removes the manifest.json files under
`rendered/`. I don't think they're used for anything.