### PR TITLE
fix cleanup for updater/test target

### DIFF
--- a/modules/argocd/Makefile
+++ b/modules/argocd/Makefile
@@ -3,10 +3,12 @@ RELEASE_TAG ?= 0.1.0
 
 ## Test argocd-image-updater annotations
 updater/test: check-prereq-variables
-	@wget --directory-prefix bin --header "PRIVATE-TOKEN: $(word 2,$(subst :, ,$(GITLAB_SECRET)))" https://gitlab.com/api/v4/projects/37621397/packages/generic/argocd-image-updater-tester/${RELEASE_TAG}/argocd-image-updater-tester
+	@mkdir -p bin
+	@wget -O bin/argocd-image-updater-tester --header "PRIVATE-TOKEN: $(word 2,$(subst :, ,$(GITLAB_SECRET)))" https://gitlab.com/api/v4/projects/37621397/packages/generic/argocd-image-updater-tester/${RELEASE_TAG}/argocd-image-updater-tester
 	@chmod +x bin/argocd-image-updater-tester
 	@bin/argocd-image-updater-tester
 	@rm bin/argocd-image-updater-tester
+	@rm bin/argocd-image-updater
 	@rm -d bin
 
 check-prereq-variables:


### PR DESCRIPTION
this fixes the issue of removing the temporary `bin/` directory failing