### PR TITLE
Run kubecfg validate as Makefile targets

### DIFF
--- a/modules/k8s/Makefile.kubecfg
+++ b/modules/k8s/Makefile.kubecfg
@@ -1,16 +1,10 @@
 ## Kubecfg helpers
-MANIFEST_DIRS:=$(shell find rendered/ -type d -name manifests 2>/dev/null)
-
-.PHONY: k8s/kubecfg/validate
+KUBECFG_TARGETS ?= $(patsubst %,k8s/kubecfg/validate/%,$(shell find rendered/ -type d -name manifests 2>/dev/null))
 
 ## Validate manifests
-k8s/kubecfg/validate:
-	@errs=0;
-	@for dir in $(MANIFEST_DIRS) ; do \
-		if ! kubecfg validate $$dir/*.yaml; then \
-			errs=$$(( $$errs + 1 )); \
-		fi ;\
-	done ;\
-	if [ "$${errs:-0}" -gt 0 ]; then \
-		exit 1; \
-	fi
+.PHONY: k8s/kubecfg/validate
+k8s/kubecfg/validate: $(KUBECFG_TARGETS)
+
+.PHONY: $(KUBECFG_TARGETS)
+$(KUBECFG_TARGETS):
+	kubecfg validate $(subst k8s/kubecfg/validate/,,$@)/*.yaml


### PR DESCRIPTION
The core-cluster-jsonnet pipeline is really slow; I want it to be
faster.

This commit will allow us to parallelize kubecfg validation by running
something like `make -j64 k8s/kubecfg/validate`... although this change will
probably make the bare `make k8s/kubecfg/validate` slower because it has to
spend more time stopping and starting kubecfg.