### PR TITLE
Allow anon admin access for dashboard development

### DIFF
--- a/modules/grafana/Makefile
+++ b/modules/grafana/Makefile
@@ -46,7 +46,7 @@ grafana/private:
 grafana/setup-local-grafana-mintel: grafana/aws-profile-check grafana/private
 	@docker pull $(GRAFANA_IMAGE)
 	@. ${TMP_GITLAB_REPO_DIRECTORY}/modules/grafana/datasource_credentials.sh && \
-	docker run --rm -d -p 3000:3000 -v ${TMP_GITLAB_REPO_DIRECTORY}/modules/grafana/provisioning:/etc/grafana/provisioning --env-file ${TMP_GITLAB_REPO_DIRECTORY}/modules/grafana/env.list --name ${GRAFANA_LOCAL_DOCKER_NAME} $(GRAFANA_IMAGE)
+	docker run --rm -d -p 3000:3000 -v ${TMP_GITLAB_REPO_DIRECTORY}/modules/grafana/provisioning:/etc/grafana/provisioning --env-file ${TMP_GITLAB_REPO_DIRECTORY}/modules/grafana/env.list -e GF_AUTH_ANONYMOUS_ORG_ROLE=Admin -e GF_AUTH_ANONYMOUS_ENABLED=true --name ${GRAFANA_LOCAL_DOCKER_NAME} $(GRAFANA_IMAGE)
 
 grafana/setup-local-grafana-oss:
 	@docker pull $(GRAFANA_IMAGE)


### PR DESCRIPTION
Providing the following envs avoids needing to login with 'admin' user each time and means we don't get the "change your password screen" which can just be skipped

```
GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
GF_AUTH_ANONYMOUS_ENABLED=true
```