### PR TITLE
Remove suffix from `sleep` (makes mac users a bit more happy)

### DIFF
--- a/modules/grafana/Makefile
+++ b/modules/grafana/Makefile
@@ -55,7 +55,7 @@ grafana/setup-grafana-syncer:
 ifeq (${CREATE_GRAFANA_INSTANCE}, true)
 # Give the grafana instance time to start up before changing the admin password in order to avoid errors
 	@echo "Starting grafana on localhost:3000 ..."
-	@sleep 3s
+	@sleep 3
 	@docker exec -it ${GRAFANA_LOCAL_DOCKER_NAME} grafana-cli --homepath "/usr/share/grafana" admin reset-admin-password ${GRAFANA_ADMIN_PASSWORD}
 endif
 	@docker pull mintel/grafana-local-sync:latest


### PR DESCRIPTION
Trailing `s` not needed, plus it makes macs sad...

With this fix it looks like dashboard development works on mac :)