### PR TITLE
Remove exit-zero from flake8 flags (it's useful)

### DIFF
--- a/modules/python/Makefile.flake8
+++ b/modules/python/Makefile.flake8
@@ -4,7 +4,7 @@
 FLAKE8 ?= $(PYTHON) -m flake8
 
 FLAKE8_OUTPUT ?= reports/python.flake8
-FLAKE8_FLAGS ?= --select=B,C,E,F,W,T4,B9 --ignore=E203,E231,E266,E501,W503 --output-file=$(FLAKE8_OUTPUT) --tee --exit-zero
+FLAKE8_FLAGS ?= --select=B,C,E,F,W,T4,B9 --ignore=E203,E231,E266,E501,W503 --output-file=$(FLAKE8_OUTPUT) --tee
 # E203: https://github.com/psf/black/issues/315
 # W503: https://github.com/psf/black/pull/36
 # E501: Let black handle line length


### PR DESCRIPTION
it's useful to have flake8 return the exit code (rather than always forcing it to zero)

I was considering replacing this with an optional `FLAKE8_EXTRA_FLAGS` ...but if it's really required can we just supply `FLAKE8_FLAGS` instead.