### PR TITLE
INFRA 28193: Fix helm and secrets usage in CI (when run in k8s)

### DIFF
--- a/modules/k8s/local/k3d.sh
+++ b/modules/k8s/local/k3d.sh
@@ -69,10 +69,11 @@ create() {
   kubectl rollout status deploy/metrics-server -n kube-system -w
   kubectl rollout status deploy/local-path-provisioner -n kube-system -w
 
-  sleep 50000
-  helm repo add stakater https://stakater.github.io/stakater-charts
-  helm install stakater stakater/reloader
-
+  if [ -z "${CI}" ]; then
+    # Not required in CI
+    helm repo add stakater https://stakater.github.io/stakater-charts
+    helm install stakater stakater/reloader --namespace default
+  fi
   make k8s/local/create-ns
 
   make k8s/local/create-imagepull-secret

--- a/modules/k8s/local/k3d.sh
+++ b/modules/k8s/local/k3d.sh
@@ -76,7 +76,10 @@ create() {
   fi
   make k8s/local/create-ns
 
-  make k8s/local/create-imagepull-secret
+  if [ -z "${CI}" ]; then
+    # Not required in CI and does not have a local docker config.json to mount
+    make k8s/local/create-imagepull-secret
+  fi
 }
 
 ## Delete the cluster

--- a/modules/k8s/local/k3d.sh
+++ b/modules/k8s/local/k3d.sh
@@ -69,6 +69,7 @@ create() {
   kubectl rollout status deploy/metrics-server -n kube-system -w
   kubectl rollout status deploy/local-path-provisioner -n kube-system -w
 
+  sleep 50000
   helm repo add stakater https://stakater.github.io/stakater-charts
   helm install stakater stakater/reloader
 


### PR DESCRIPTION
Helm can grab the default namespace from the CI's auto-mounted service-account creds.

```
/var/run/secrets/kubernetes.io/serviceaccount/namespace
```
https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/#directly-accessing-the-rest-api

In this case we run our CI inside k8s, so this `namespace` for the CI build pod is currently set to the namespace that the CI Deployment runs in  (which is not `default`).

That namespace will not exists in the k3d install..so it won't work :)

---

A workaround is to set the namespace when running Helm. 

More than that though, we don't need a couple of tasks to run in CI, so I've disabled them entirely.