### PR TITLE
tanka/generate: Remove dangling rendered directories

### DIFF
--- a/modules/k8s/tanka/generate.sh
+++ b/modules/k8s/tanka/generate.sh
@@ -109,8 +109,10 @@ for env_name in $(tk env list environments --names -l "$(join_arr , "${SELECTOR[
 done
 
 # Handle case where environment itself is deleted.
-# We need to clean up any rendered environments that no longer exist
-# as the deleted env wouldn't have shown up in `tk env list ...`
+# We need to clean up any rendered environments that no longer exist as the deleted env wouldn't have shown up in
+# `tk env list ...`
+# This snippet finds all environments under the `./rendered` directory and checks if the associated  path exists
+# under `./environments`. If it does not find a match, it deletes the rendered directory.
 rendered_envs=$(find rendered/environments -type d | cut -d/ -f2,3 | sort | uniq  | grep -v "environments$")
 for env_path in $rendered_envs; do
   if [[ ! -d "$env_path" ]];


### PR DESCRIPTION
If we delete an environment the existing script would not have removed the rendered manifests.

This would then fail the CI.

For example deleting an app or a whole environment should result in the rendered manifests being deleted too when `make tanka/generate` is called.