### PR TITLE
Fix comments on tf-tool-versions file

### DIFF
--- a/modules/satoshi/tf-tool-versions
+++ b/modules/satoshi/tf-tool-versions
@@ -1,8 +1,5 @@
 #
-# DO NOT OVERRIDE THIS FILE. AUTO-GENERATED FROM 'make satoshi/update-tools'.
-#
-# If you are adding any apps to the master file in build-harness-extensions remember to add an install function to the
-# terraform cloud agent (https://github.com/mintel/tfc-agent/blob/main/install-binaries.sh) too.
+# DO NOT OVERRIDE THIS FILE. AUTO-GENERATED FROM 'make satoshi/update-tools/tf'.
 #
 
 #asdf:plugin add terraform


### PR DESCRIPTION
- Running the `make satoshi/update-tools` command without the `/tf` suffix pulls the jsonnet file rather than the terraform one
- The instructions to update the tfc-agent image are no longer necessary