### PR TITLE
Fix Tanka deprecated flag warning

### DIFF
--- a/modules/k8s/tanka/generate.sh
+++ b/modules/k8s/tanka/generate.sh
@@ -98,7 +98,7 @@ for env_name in $(tk env list environments --names -l "$(join_arr , "${SELECTOR[
 done
 
 # Export rendered manifests for each environment
-tk export "$TANKA_REPO_DIR/rendered/" "$TANKA_REPO_DIR/environments" -r -l "$(join_arr , "${SELECTOR[@]}")" --format="$TANKA_EXPORT_FMT" --merge
+tk export "$TANKA_REPO_DIR/rendered/" "$TANKA_REPO_DIR/environments" -r -l "$(join_arr , "${SELECTOR[@]}")" --format="$TANKA_EXPORT_FMT" --merge-strategy=fail-on-conflicts
 find "$TANKA_REPO_DIR/rendered" -name "manifest.json" -delete
 
 # Re-populate the kustomization file


### PR DESCRIPTION
Tanka is printing warnings like:

> Flag --merge has been deprecated, use --merge-strategy=fail-on-conflicts instead

We might want to look at the new features of this flag later; it might
replace some of the bash scripting we've written.
https://tanka.dev/exporting#partial-export-in-a-gitops-context