### PR TITLE
Fix crash due to terminal colors with no terminal

### DIFF
--- a/modules/satoshi/Makefile
+++ b/modules/satoshi/Makefile
@@ -1,8 +1,8 @@
-S_RED := $(shell tput -Txterm setaf 1)
-S_GRN := $(shell tput -Txterm setaf 2)
-S_YLW := $(shell tput -Txterm setaf 3)
-S_RST := $(shell tput -Txterm sgr0)
-S_BLD := $(shell tput bold)
+S_RED := $(shell tput setaf 1 2> /dev/null || true)
+S_GRN := $(shell tput setaf 2 2> /dev/null || true)
+S_YLW := $(shell tput setaf 3 2> /dev/null || true)
+S_RST := $(shell tput sgr0 2> /dev/null || true)
+S_BLD := $(shell tput bold 2> /dev/null || true)
 
 REQUIRED_SATOSHI_BINS := conftest helm jb jsonnet kubectl kustomize opa pluto tk yq
 


### PR DESCRIPTION
We attempt to print some pretty colors in a few places of our build-harness-extensions. However, if these Makefiles are being used in a non-tty environment (such as renovate's postUpdateTasks) the `tput` command will fail with an error, causing the whole make command to fail. This commit falls back to ordinary, unformatted text when TERM is not set or unknown.