### PR TITLE
Force update-makefile and update-tools to run

### DIFF
--- a/modules/satoshi/Makefile
+++ b/modules/satoshi/Makefile
@@ -25,7 +25,7 @@ satoshi/update-makefile:
 	@make satoshi/update-makefile/k8s
 
 ## Update Satoshi Makefile for a particular toolset e.g. k8s and tf
-satoshi/update-makefile/%:
+satoshi/update-makefile/%: FORCE
 	$(shell curl -sSL -o Makefile "https://raw.githubusercontent.com/mintel/build-harness-extensions/main/modules/satoshi/${*}-makefile.template")
 
 ## Update Satoshi asdf .tool-versions for k8s toolset
@@ -33,6 +33,8 @@ satoshi/update-tools:
 	@make satoshi/update-tools/k8s
 
 ## Update Satoshi asdf .tool-versions for a particular toolset e.g. k8s and tf
-satoshi/update-tools/%:
+satoshi/update-tools/%: FORCE
 	$(shell curl -sSL -o .tool-versions "https://raw.githubusercontent.com/mintel/build-harness-extensions/main/modules/satoshi/${*}-tool-versions")
 	@make asdf/install
+
+FORCE:


### PR DESCRIPTION
When we run a Makefile command like `make satoshi/update-makefile/k8s`, we want Make to always update the target file. Normally you would do this by adding your target to `.PHONY: <mytarget>`.

See: https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html

But `.PHONY` doesn't support pattern rules like
`satoshi/update-makefile/%s`. We need to do something different to force those to always run.

See: https://www.gnu.org/software/make/manual/html_node/Force-Targets.html