### PR TITLE
Add kyverno/test target

### DIFF
--- a/modules/kyverno/Makefile
+++ b/modules/kyverno/Makefile
@@ -1,0 +1,39 @@
+## OPA (open-policy-agent) helpers
+KYVERNO_POLICY_BRANCH ?= main
+KYVERNO_POLICY_DIR = /tmp/kyverno-policy
+KYVERNO_POLICY_SUBDIR ?= rendered/environments/kyverno/aws.prod/manifests
+KYVERNO_POLICY_REPO ?= git@gitlab.com:mintel/satoshi/kubernetes/jsonnet/sre/core-cluster-jsonnet.git
+MANIFEST_DIRS:=$(shell find rendered/ -type d -name manifests 2>/dev/null)
+
+.PHONY: kyverno/check-env kyverno/clone-policy kyverno/test
+
+# Check Kyverno environment is suitable
+kyverno/check-env:
+ifndef KYVERNO_POLICY_REPO
+	$(error KYVERNO_POLICY_REPO is undefined)
+endif
+
+	@if [ ! -d ./rendered ]; then \
+		echo "rendered manifests directory does not exist, run: make tanka/generate" ;\
+		exit 1 ;\
+	fi
+
+## Git clone policies (requires KYVERNO_POLICY_REPO argument)
+kyverno/clone-policy: kyverno/check-env
+	@if [ -d "$(KYVERNO_POLICY_DIR)" ]; then \
+		rm -rf $(KYVERNO_POLICY_DIR) ;\
+	fi ;\
+	git clone --depth=1 $(KYVERNO_POLICY_REPO) -b $(KYVERNO_POLICY_BRANCH) $(KYVERNO_POLICY_DIR) ;\
+
+## Validate manifests
+kyverno/test: satoshi/check-deps kyverno/clone-policy
+	@errs=0;
+	@for dir in $(MANIFEST_DIRS) ; do \
+		echo "Testing dir $$dir..."; \
+		if ! printf -- '--resource\0%s\0'  $$dir/*.yaml | xargs -0 kyverno apply $(KYVERNO_POLICY_DIR)/$(KYVERNO_POLICY_SUBDIR); then \
+			errs=$$(( $$errs + 1 )); \
+		fi ;\
+	done ;\
+	if [ "$${errs:-0}" -gt 0 ]; then \
+		exit 1; \
+	fi

--- a/modules/satoshi/k8s-makefile.template
+++ b/modules/satoshi/k8s-makefile.template
@@ -1,7 +1,7 @@
 #
 # DO NOT OVERRIDE THIS FILE. AUTO-GENERATED FROM 'make satoshi/update-makefile'
 #
-export HELP_FILTER ?= asdf|grafana|jsonnet|k8s|opa|pluto|satoshi|updater
+export HELP_FILTER ?= asdf|grafana|jsonnet|k8s|kyverno|opa|pluto|satoshi|updater
 -include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)
 export BUILD_HARNESS_PATH ?= $(shell 'pwd')
 export BUILD_HARNESS_EXTENSIONS_PATH ?= $(BUILD_HARNESS_PATH)/build-harness-extensions

--- a/modules/satoshi/k8s-tool-versions
+++ b/modules/satoshi/k8s-tool-versions
@@ -40,6 +40,10 @@ kubeval v0.16.1
 #asdf:plugin add kustomize
 kustomize 5.0.1
 
+#asdf:plugin add kyverno-cli https://github.com/hobaen/asdf-kyverno-cli.git
+#renovate: depName=kyverno/kyverno
+kyverno-cli 1.10.0
+
 #asdf:plugin add opa
 #renovate: depName=open-policy-agent/opa
 opa 0.50.0


### PR DESCRIPTION
This commit adds a Makefile target for testing our current set of Kyverno policies against jsonnet repo rendered manifests. It is not currently aware of any PolicyExceptions we set up, so it isn't currently suitable for adding to our CI pipeline.