### PR TITLE
Remove v from conftest version

### DIFF
--- a/modules/satoshi/k8s-tool-versions
+++ b/modules/satoshi/k8s-tool-versions
@@ -7,7 +7,7 @@ amtool 0.25.0
 
 #asdf:plugin add conftest
 #renovate: depName=open-policy-agent/conftest
-conftest v0.39.2
+conftest 0.39.2
 
 #asdf:plugin add go-jsonnet https://github.com/sirikon/asdf-go-jsonnet.git
 #renovate: depName=google/go-jsonnet


### PR DESCRIPTION
Newer versions of the conftest plugin for asdf don't seem to like the version number being prefixed with a `v`. It results in trying to download a URL like:

https://github.com/open-policy-agent/conftest/releases/download/vv0.39.2/conftest_v0.39.2_Linux_x86_64.tar.gz

Note the double `vv`.