### PR TITLE
Create local namespaces from rendered manifests

### DIFF
--- a/modules/k8s/local/create-ns.sh
+++ b/modules/k8s/local/create-ns.sh
@@ -2,12 +2,12 @@
 
 K3D_CLUSTER_NAME=${K3D_CLUSTER_NAME:-"local"}
 
-if [ "$(k3d cluster list | grep -o -E "^${K3D_CLUSTER_NAME}")" ]; then
+if k3d cluster list | grep -q -o -E "^${K3D_CLUSTER_NAME}"; then
   set +e
-  namespaces=$(find rendered -type f -path '*/manifests/*.yaml' -print0 | xargs -0 -P1 yq eval-all --output-format csv '[.metadata.namespace] | map(select(. != null))' | tr ',' '\n' | sort -u)
+  namespaces="$(find rendered -type f -path '*/manifests/*.yaml' -print0 | xargs -0 -P1 yq eval-all --output-format csv '[.metadata.namespace] | map(select(. != null))' | tr ',' '\n' | sort -u)"
   while IFS= read -r namespace; do
     echo "Creating namespace $namespace ....."
-    out=$(kubectl --context k3d-${K3D_CLUSTER_NAME} create namespace $namespace 2>&1)
+    out=$(kubectl --context "k3d-${K3D_CLUSTER_NAME}" create namespace "$namespace" 2>&1)
     if  [[ "$out" == *"AlreadyExists"* ]]; then
       echo "Namespace $namespace already exists, skipping"
     else

--- a/modules/k8s/local/create-ns.sh
+++ b/modules/k8s/local/create-ns.sh
@@ -4,7 +4,7 @@ K3D_CLUSTER_NAME=${K3D_CLUSTER_NAME:-"local"}
 
 if [ "$(k3d cluster list | grep -o -E "^${K3D_CLUSTER_NAME}")" ]; then
   set +e
-  namespaces=$(tk env list --json | jq -r '.[].spec.namespace' | sort | uniq)
+  namespaces=$(find rendered -type f -path '*/manifests/*.yaml' -print0 | xargs -0 -P1 yq eval-all --output-format csv '[.metadata.namespace] | map(select(. != null))' | tr ',' '\n' | sort -u)
   while IFS= read -r namespace; do
     echo "Creating namespace $namespace ....."
     out=$(kubectl --context k3d-${K3D_CLUSTER_NAME} create namespace $namespace 2>&1)


### PR DESCRIPTION
In some cases, such as namespace-jsonnet, we have apps that output manifests across multiple namespaces. Therefore, when creating namespaces in a local cluster, we can't always rely on the namespace specified in the Tanka environment file.

Change the `make k8s/local/create-ns` target to extract the namespace names from the rendered manifests instead.