### PR TITLE
Revert "INFRA-30830: Use bitnami grafana image"

### DIFF
--- a/modules/grafana/Makefile
+++ b/modules/grafana/Makefile
@@ -3,8 +3,7 @@ GRAFANA_ADMIN_PASSWORD ?= admin
 LOCAL_DASHBOARD_DIRECTORY ?= $(shell ${BUILD_HARNESS_EXTENSIONS_PATH}/modules/grafana/scripts/local_dashboard_directory_prompt.sh)
 BUILD_HARNESS_EXTENSIONS_PRIVATE_BRANCH ?= main
 CREATE_GRAFANA_INSTANCE ?= true
-GRAFANA_IMAGE ?= bitnami/grafana:9.3.6
-GRAFANA_HOME ?= /opt/bitnami/grafana
+GRAFANA_IMAGE ?= grafana/grafana:9.3.6
 
 # Generally no reason to change these defaults, but values don't matter as long as they're different from eachother
 GRAFANA_LOCAL_DOCKER_NAME = grafana_local
@@ -47,7 +46,7 @@ grafana/private:
 grafana/setup-local-grafana-mintel: grafana/aws-profile-check grafana/private
 	@docker pull $(GRAFANA_IMAGE)
 	@. ${TMP_GITLAB_REPO_DIRECTORY}/modules/grafana/datasource_credentials.sh && \
-	docker run --rm -d -p 3000:3000 -v ${TMP_GITLAB_REPO_DIRECTORY}/modules/grafana/provisioning/datasources:${GRAFANA_HOME}/conf/provisioning/datasources -v ${HOME}/.aws:${GRAFANA_HOME}/.aws --env-file ${TMP_GITLAB_REPO_DIRECTORY}/modules/grafana/env.list -e GF_AUTH_ANONYMOUS_ORG_ROLE=Admin -e GF_AUTH_ANONYMOUS_ENABLED=true -e GF_FEATURE_TOGGLES_ENABLE=traceqlEditor -e AWS_PROFILE=${AWS_PROFILE} -e AWS_SDK_LOAD_CONFIG=true -e AWS_EC2_METADATA_DISABLED=1 --name ${GRAFANA_LOCAL_DOCKER_NAME} $(GRAFANA_IMAGE)
+	docker run --rm -d -p 3000:3000 --user $(id):$(id) -v ${TMP_GITLAB_REPO_DIRECTORY}/modules/grafana/provisioning:/etc/grafana/provisioning -v ${HOME}/.aws:/usr/share/grafana/.aws --env-file ${TMP_GITLAB_REPO_DIRECTORY}/modules/grafana/env.list -e GF_AUTH_ANONYMOUS_ORG_ROLE=Admin -e GF_AUTH_ANONYMOUS_ENABLED=true -e GF_FEATURE_TOGGLES_ENABLE=traceqlEditor -e AWS_PROFILE=${AWS_PROFILE} -e AWS_SDK_LOAD_CONFIG=true -e AWS_EC2_METADATA_DISABLED=1 --name ${GRAFANA_LOCAL_DOCKER_NAME} $(GRAFANA_IMAGE)
 grafana/setup-local-grafana-oss:
 	@docker pull $(GRAFANA_IMAGE)
 	@docker run --rm -d -p 3000:3000 --name ${GRAFANA_LOCAL_DOCKER_NAME} $(GRAFANA_IMAGE)
@@ -56,8 +55,8 @@ grafana/setup-grafana-syncer:
 ifeq (${CREATE_GRAFANA_INSTANCE}, true)
 # Give the grafana instance time to start up before changing the admin password in order to avoid errors
 	@echo "Starting grafana on localhost:3000 ..."
-	@sleep 5
-	@docker exec -it ${GRAFANA_LOCAL_DOCKER_NAME} grafana-cli --homepath "${GRAFANA_HOME}" admin reset-admin-password ${GRAFANA_ADMIN_PASSWORD}
+	@sleep 3
+	@docker exec -it ${GRAFANA_LOCAL_DOCKER_NAME} grafana-cli --homepath "/usr/share/grafana" admin reset-admin-password ${GRAFANA_ADMIN_PASSWORD}
 endif
 	@docker pull mintel/grafana-local-sync:latest
 	@docker run --rm -it --mount type=bind,source=$$PWD/${LOCAL_DASHBOARD_DIRECTORY},target=${CONTAINER_DASHBOARD_DIRECTORY}/LocalDev --network="host" --name ${GRAFANA_SYNC_DOCKER_NAME} mintel/grafana-local-sync:latest -user admin -pass ${GRAFANA_ADMIN_PASSWORD} -dir ${CONTAINER_DASHBOARD_DIRECTORY}


### PR DESCRIPTION
Reverts mintel/build-harness-extensions#159

Most likely not possible since the image runs as non-root and I can't mount aws-sso creds into this container in a usable manner :)