### PR TITLE
Fix asdf renovatebot config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,10 +18,11 @@
         ".*tool-versions$",
       ],
       matchStrings: [
-        "#\\s*renovate:( datasource=(?<datasource>.*?))? depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( depType=(?<depType>.*?))?\\n[^\\s]+\\s+(?<currentValue>.*)",
+        "#\\s*renovate:( datasource=(?<datasource>.*?))? depName=(?<depName>.*?)(?: extractVersion=(?<extractVersion>.+?))?( versioning=(?<versioning>.*?))?( depType=(?<depType>.*?))?\\n[^\\s]+\\s+(?<currentValue?.*)",
       ],
       datasourceTemplate: "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
       versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+      extractVersionTemplate: "{{#if extractVersion}}{{{extractVersion}}}{{else}}^v?(?<version>.*)$"{{/if}}"
     },
   ],
   packageRules: [


### PR DESCRIPTION
asdf is supposed to allow version numbers both like `1.2.3` and `v1.2.3`. However, the implementation is left up to the underlying plugin and they often don't get it right, resulting in asdf trying to download from URLs like
`https://github.com/blah/blah/releases/vv1.2.3/my-tool-x86_64`.

This commit will instruct renovatebot to write version numbers like `1.2.3`, but also allows us to override it on a per-tool basis to write version numbers like `v1.2.3` if the underlying plugin needs them to be written that way.