### PR TITLE
Upgrade tanka to v0.26.0

### DIFF
--- a/modules/satoshi/k8s-tool-versions
+++ b/modules/satoshi/k8s-tool-versions
@@ -54,7 +54,7 @@ pluto 5.16.0
 
 #asdf:plugin add tanka
 #renovate: depName=grafana/tanka
-tanka 0.24.0
+tanka 0.26.0
 
 #asdf:plugin add yamllint
 #renovate: depName=adrienverge/yamllint


### PR DESCRIPTION
I need the OCI Helm chart support that was added in v0.25.0.