### PR TITLE
INFRA-32499: Add pre-rendering Helm chart patching support to Tanka repos

### DIFF
--- a/modules/k8s/Makefile.tanka
+++ b/modules/k8s/Makefile.tanka
@@ -25,9 +25,13 @@ endif
 
 ## Check if there are any patch files in the charts/ directory and apply them to the relevant charts
 k8s/tanka/charts/patch:
+ifneq ("$(wildcard ./charts)", "")
+ifneq ("$(wildcard ./charts/*.patch)", "")
 	@for f in charts/*.patch; do \
 		patch -d charts -p0 < $$f; \
 	done
+endif
+endif
 
 ## Update Helm Chart
 k8s/tanka/update-chart/%:

--- a/modules/k8s/Makefile.tanka
+++ b/modules/k8s/Makefile.tanka
@@ -23,7 +23,7 @@ endif
 	@tk tool charts vendor
 endif
 
-## If there are any patch files in the charts/ directory and apply them to the relevant charts
+## Check if there are any patch files in the charts/ directory and apply them to the relevant charts
 k8s/tanka/charts/patch:
 	@for f in charts/*.patch; do \
 		patch -d charts -p0 < $$f; \

--- a/modules/k8s/Makefile.tanka
+++ b/modules/k8s/Makefile.tanka
@@ -9,10 +9,10 @@ endif
 
 TK_APPLY_FLAGS ?= --apply-strategy=server --force
 
-.PHONY: k8s/tanka/fmt k8s/tanka/fmt-test k8s/tanka/generate k8s/tanka/generate/% k8s/tanka/apply/% k8s/tanka/delete/% k8s/tanka/update-chart/% k8s/tanka/new-app/%
+.PHONY: k8s/tanka/charts/vendor k8s/tanka/charts/patch k8s/tanka/fmt k8s/tanka/fmt-test k8s/tanka/generate k8s/tanka/generate/% k8s/tanka/apply/% k8s/tanka/delete/% k8s/tanka/update-chart/% k8s/tanka/new-app/%
 
 ## Vendor charts
-k8s/tanka/vendor/charts:
+k8s/tanka/charts/vendor:
 ifneq ("$(wildcard ./chartfile.yaml)", "")
 ifdef ALWAYS_VENDOR_CHARTS
 	@IFS=',' read -ra ADDR <<< "${ALWAYS_VENDOR_CHARTS}"; \
@@ -22,6 +22,12 @@ ifdef ALWAYS_VENDOR_CHARTS
 endif
 	@tk tool charts vendor
 endif
+
+## If there are any patch files in the charts/ directory and apply them to the relevant charts
+k8s/tanka/charts/patch:
+	@for f in charts/*.patch; do \
+		patch -d charts -p0 < $$f; \
+	done
 
 ## Update Helm Chart
 k8s/tanka/update-chart/%:
@@ -36,11 +42,11 @@ k8s/tanka/fmt-test: satoshi/check-deps
 	tk fmt --test .
 
 ## Generate manifests using tanka
-k8s/tanka/generate: satoshi/check-deps jsonnet/install k8s/tanka/vendor/charts
+k8s/tanka/generate: satoshi/check-deps jsonnet/install k8s/tanka/charts/vendor k8s/tanka/charts/patch
 	@@${BUILD_HARNESS_EXTENSIONS_PATH}/modules/k8s/tanka/generate.sh $(GENERATE_ARGS)
 
 ## Generate manifests of specific app using tanka
-k8s/tanka/generate/%: satoshi/check-deps jsonnet/install k8s/tanka/vendor/charts
+k8s/tanka/generate/%: satoshi/check-deps jsonnet/install k8s/tanka/charts/vendor
 	@@${BUILD_HARNESS_EXTENSIONS_PATH}/modules/k8s/tanka/generate.sh --app $*
 
 ## Apply rendered manifests of an app to the local cluster


### PR DESCRIPTION
The Fusion >=5.6.0 Helm charts have an issue that prevents them from being rendered before they are even passed into the Jsonnet bit. This means we can’t monkey patch manifests with Jsonnet in the usual way and the charts are closed source so we can’t change them upstream.

We’ve raised a request with Lucidworks to fix this but in the meantime we need better support for patching the files downloaded to the `charts/` directory.