### PR TITLE
Fix repatching attempts

### DIFF
--- a/modules/k8s/Makefile.tanka
+++ b/modules/k8s/Makefile.tanka
@@ -27,8 +27,13 @@ endif
 k8s/tanka/charts/patch:
 ifneq ("$(wildcard ./charts)", "")
 ifneq ("$(wildcard ./charts/*.patch)", "")
-	@for f in charts/*.patch; do \
-		patch -d charts -p0 < $$f; \
+	@cd charts ;\
+	for f in *.patch; do \
+		patch --strip=0 --forward --reject-file=$$f.rej < $$f ;\
+		rc=$$? ;\
+		if [[ $$rc -gt 1 ]]; then \
+			exit $$rc ;\
+		fi ;\
 	done
 endif
 endif


### PR DESCRIPTION
`patch` will always run when a patch is found and it will exit with code 1 if it skips a file because it has already been patched. Exit code 2 is for "more serious" issues according to `man patch` so we'll ignore 1s and exit on >1s.