### PR TITLE
Infra 39554: Update `make kyverno/test` to use PolicyExceptions

### DIFF
--- a/modules/kyverno/Makefile
+++ b/modules/kyverno/Makefile
@@ -33,7 +33,6 @@ kyverno/test: satoshi/check-deps kyverno/clone-policy
 	yq eval --inplace 'del(.metadata.namespace)' combined-cluster-policies.yaml ;\
 	yq eval --inplace 'del(.metadata.labels["app.mintel.com/region"])' combined-cluster-policies.yaml ;\
 	yq eval-all *.PolicyException*.yaml > combined-policy-exceptions.yaml ;\
-	yq eval --inplace '.apiVersion="kyverno.io/v2"' combined-policy-exceptions.yaml ;\
 	popd ;\
 	for dir in $(MANIFEST_DIRS) ; do \
 		matchedfiles=$$(find $${dir} -type f -name 'apps-v1.Deployment*.yaml' -o -name 'apps-v1.StatefulSet*' -o -name 'apps-v1.DaemonSet*' -o -name 'batch-v1.CronJob*' -o -name 'batch-v1.Job*') ;\

--- a/modules/kyverno/Makefile
+++ b/modules/kyverno/Makefile
@@ -38,7 +38,6 @@ kyverno/test: satoshi/check-deps kyverno/clone-policy
 		matchedfiles=$$(find $${dir} -type f -name 'apps-v1.Deployment*.yaml' -o -name 'apps-v1.StatefulSet*' -o -name 'apps-v1.DaemonSet*' -o -name 'batch-v1.CronJob*' -o -name 'batch-v1.Job*') ;\
 		if [ ! -z "$${matchedfiles}" ]; then \
 			if ! printf -- '--resource\0%s\0' $$(find $${dir} -type f -name 'apps-v1.Deployment*.yaml' -o -name 'apps-v1.StatefulSet*' -o -name 'apps-v1.DaemonSet*' -o -name 'batch-v1.CronJob*' -o -name 'batch-v1.Job*') | xargs -0 kyverno apply --table $(KYVERNO_POLICY_DIR)/$(KYVERNO_POLICY_SUBDIR)/combined-cluster-policies.yaml --exceptions $(KYVERNO_POLICY_DIR)/$(KYVERNO_POLICY_SUBDIR)/combined-policy-exceptions.yaml; then \
-				exit 1; \
 				errs=$$(( $$errs + 1 )); \
 			fi ;\
 		fi; \

--- a/modules/kyverno/Makefile
+++ b/modules/kyverno/Makefile
@@ -28,9 +28,15 @@ kyverno/clone-policy: kyverno/check-env
 ## Validate manifests
 kyverno/test: satoshi/check-deps kyverno/clone-policy
 	@errs=0;
-	@for dir in $(MANIFEST_DIRS) ; do \
-		echo "Testing dir $$dir..."; \
-		if ! printf -- '--resource\0%s\0'  $$dir/*.yaml | xargs -0 kyverno apply $(KYVERNO_POLICY_DIR)/$(KYVERNO_POLICY_SUBDIR); then \
+	pushd $(KYVERNO_POLICY_DIR)/$(KYVERNO_POLICY_SUBDIR) ;\
+	yq eval-all *.ClusterPolicy*.yaml > combined-cluster-policies.yaml ;\
+	yq eval --inplace 'del(.metadata.namespace)' combined-cluster-policies.yaml ;\
+	yq eval --inplace 'del(.metadata.labels["app.mintel.com/region"])' combined-cluster-policies.yaml ;\
+	yq eval-all *.PolicyException*.yaml > combined-policy-exceptions.yaml ;\
+	yq eval --inplace '.apiVersion="kyverno.io/v2"' combined-policy-exceptions.yaml ;\
+	popd ;\
+	for dir in $(MANIFEST_DIRS) ; do \
+		if ! printf -- '--resource\0%s\0' $$(find $${dir} -type f -name 'apps-v1.Deployment*.yaml'-o -name 'apps-v1.StatefulSet*' -o -name 'apps-v1.DaemonSet*' -o -name 'batch-v1.CronJob*' -o -name 'batch-v1.Job*') | xargs -0 kyverno apply --table $(KYVERNO_POLICY_DIR)/$(KYVERNO_POLICY_SUBDIR)/combined-cluster-policies.yaml --exceptions $(KYVERNO_POLICY_DIR)/$(KYVERNO_POLICY_SUBDIR)/combined-policy-exceptions.yaml; then \
 			errs=$$(( $$errs + 1 )); \
 		fi ;\
 	done ;\

--- a/modules/kyverno/Makefile
+++ b/modules/kyverno/Makefile
@@ -36,9 +36,13 @@ kyverno/test: satoshi/check-deps kyverno/clone-policy
 	yq eval --inplace '.apiVersion="kyverno.io/v2"' combined-policy-exceptions.yaml ;\
 	popd ;\
 	for dir in $(MANIFEST_DIRS) ; do \
-		if ! printf -- '--resource\0%s\0' $$(find $${dir} -type f -name 'apps-v1.Deployment*.yaml'-o -name 'apps-v1.StatefulSet*' -o -name 'apps-v1.DaemonSet*' -o -name 'batch-v1.CronJob*' -o -name 'batch-v1.Job*') | xargs -0 kyverno apply --table $(KYVERNO_POLICY_DIR)/$(KYVERNO_POLICY_SUBDIR)/combined-cluster-policies.yaml --exceptions $(KYVERNO_POLICY_DIR)/$(KYVERNO_POLICY_SUBDIR)/combined-policy-exceptions.yaml; then \
-			errs=$$(( $$errs + 1 )); \
-		fi ;\
+		matchedfiles=$$(find $${dir} -type f -name 'apps-v1.Deployment*.yaml' -o -name 'apps-v1.StatefulSet*' -o -name 'apps-v1.DaemonSet*' -o -name 'batch-v1.CronJob*' -o -name 'batch-v1.Job*') ;\
+		if [ ! -z "$${matchedfiles}" ]; then \
+			if ! printf -- '--resource\0%s\0' $$(find $${dir} -type f -name 'apps-v1.Deployment*.yaml' -o -name 'apps-v1.StatefulSet*' -o -name 'apps-v1.DaemonSet*' -o -name 'batch-v1.CronJob*' -o -name 'batch-v1.Job*') | xargs -0 kyverno apply --table $(KYVERNO_POLICY_DIR)/$(KYVERNO_POLICY_SUBDIR)/combined-cluster-policies.yaml --exceptions $(KYVERNO_POLICY_DIR)/$(KYVERNO_POLICY_SUBDIR)/combined-policy-exceptions.yaml; then \
+				exit 1; \
+				errs=$$(( $$errs + 1 )); \
+			fi ;\
+		fi; \
 	done ;\
 	if [ "$${errs:-0}" -gt 0 ]; then \
 		exit 1; \

--- a/modules/satoshi/k8s-tool-versions
+++ b/modules/satoshi/k8s-tool-versions
@@ -41,7 +41,7 @@ kustomize 5.0.1
 
 #asdf:plugin add kyverno-cli https://github.com/hobaen/asdf-kyverno-cli.git
 #renovate: depName=kyverno/kyverno
-kyverno-cli 1.10.0
+kyverno-cli 1.13.4
 
 #asdf:plugin add opa
 #renovate: depName=open-policy-agent/opa


### PR DESCRIPTION
This MR requires the latest version of kyverno-cli (tested against 1.13.4)

It allows `make kyverno/test` to be run locally (and in CI), without the need for deploying a k3d/kind cluster (so speeds up jobs).

`kyverno-cli` now supports passing through `--exceptions` which means this helper can be run locally.

The change is:

1. Patch `ClusterPolicy` manifests to remove the `.metadata.namespace` field. This is an issue with how we generated the rendered manifests with Tanka. This previously was not an issue as the tests were run in a k8s cluster. It's an issue now as the policies do not match as they are namespaced (probably a bug in kyverno...)
3. Combine yaml where required to avoid the need for extra loops
4. Update `kyverno apply` to pass in `--exceptions` and also configure the output to `--table`
