### PR TITLE
INFRA-40823: Fix grafana-syncer permissions issue specifying

### DIFF
--- a/modules/grafana/Makefile
+++ b/modules/grafana/Makefile
@@ -19,6 +19,8 @@ TMP_CORE_CLUSTER_JSONNET = /tmp/core-cluster-jsonnet
 endif
 TMP_GRAFANA_DATASOURCES = /tmp/grafana-datasources.yaml
 
+UID=$(shell id -u)
+
 .PHONY: grafana/develop grafana/develop-oss grafana/cleanup grafana/aws-profile-check grafana/core-cluster-jsonnet grafana/setup-local-grafana-mintel grafana/setup-local-grafana-oss grafana/setup-grafana-syncer
 
 ifeq (${CREATE_GRAFANA_INSTANCE}, true)
@@ -63,7 +65,7 @@ grafana/setup-local-grafana-mintel: grafana/aws-profile-check grafana/core-clust
 	@. ${BUILD_HARNESS_EXTENSIONS_PATH}/modules/grafana/scripts/datasource_credentials.sh && \
 		MINTEL_BASE_URL='$(MINTEL_BASE_URL)' \
 		docker run \
-			--rm -d -p 3000:3000 --user $(shell id -u):$(shell id -u) \
+			--rm -d -p 3000:3000 --user $(UID):$(UID) \
 			-v ${TMP_GRAFANA_DATASOURCES}:/etc/grafana/provisioning/datasources/automatic.yml \
 			-v ${HOME}/.aws:/usr/share/grafana/.aws \
 			--env-file ${BUILD_HARNESS_EXTENSIONS_PATH}/modules/grafana/env.list \
@@ -82,6 +84,7 @@ grafana/setup-local-grafana-oss:
 	@docker run --rm -d -p 3000:3000 --name ${GRAFANA_LOCAL_DOCKER_NAME} $(GRAFANA_IMAGE)
 
 grafana/setup-grafana-syncer:
+	@set -x;
 ifeq (${CREATE_GRAFANA_INSTANCE}, true)
 # Give the grafana instance time to start up before changing the admin password in order to avoid errors
 	@echo "Starting grafana on localhost:3000 ..."
@@ -90,5 +93,5 @@ ifeq (${CREATE_GRAFANA_INSTANCE}, true)
 	@docker exec -it ${GRAFANA_LOCAL_DOCKER_NAME} grafana cli --homepath "/usr/share/grafana" admin reset-admin-password ${GRAFANA_ADMIN_PASSWORD}
 endif
 	@docker pull mintel/grafana-local-sync:latest
-	@docker run --rm -it --user $(shell id -u):$(shell id -u) --mount type=bind,source=$$PWD/${LOCAL_DASHBOARD_DIRECTORY},target=${CONTAINER_DASHBOARD_DIRECTORY}/LocalDev --network="host" --user $$id:1000 --name ${GRAFANA_SYNC_DOCKER_NAME} mintel/grafana-local-sync:latest -user admin -pass ${GRAFANA_ADMIN_PASSWORD} -dir ${CONTAINER_DASHBOARD_DIRECTORY}
+	@docker run --rm -it --user $(UID):$(UID) --mount type=bind,source=$$PWD/${LOCAL_DASHBOARD_DIRECTORY},target=${CONTAINER_DASHBOARD_DIRECTORY}/LocalDev --network="host" --name ${GRAFANA_SYNC_DOCKER_NAME} mintel/grafana-local-sync:latest -user admin -pass ${GRAFANA_ADMIN_PASSWORD} -dir ${CONTAINER_DASHBOARD_DIRECTORY}
 	@$(MAKE) grafana/cleanup

--- a/modules/grafana/Makefile
+++ b/modules/grafana/Makefile
@@ -63,7 +63,7 @@ grafana/setup-local-grafana-mintel: grafana/aws-profile-check grafana/core-clust
 	@. ${BUILD_HARNESS_EXTENSIONS_PATH}/modules/grafana/scripts/datasource_credentials.sh && \
 		MINTEL_BASE_URL='$(MINTEL_BASE_URL)' \
 		docker run \
-			--rm -d -p 3000:3000 --user $(id):$(id) \
+			--rm -d -p 3000:3000 --user $(shell id -u):$(shell id -u) \
 			-v ${TMP_GRAFANA_DATASOURCES}:/etc/grafana/provisioning/datasources/automatic.yml \
 			-v ${HOME}/.aws:/usr/share/grafana/.aws \
 			--env-file ${BUILD_HARNESS_EXTENSIONS_PATH}/modules/grafana/env.list \
@@ -90,5 +90,5 @@ ifeq (${CREATE_GRAFANA_INSTANCE}, true)
 	@docker exec -it ${GRAFANA_LOCAL_DOCKER_NAME} grafana cli --homepath "/usr/share/grafana" admin reset-admin-password ${GRAFANA_ADMIN_PASSWORD}
 endif
 	@docker pull mintel/grafana-local-sync:latest
-	@docker run --rm -it --mount type=bind,source=$$PWD/${LOCAL_DASHBOARD_DIRECTORY},target=${CONTAINER_DASHBOARD_DIRECTORY}/LocalDev --network="host" --name ${GRAFANA_SYNC_DOCKER_NAME} mintel/grafana-local-sync:latest -user admin -pass ${GRAFANA_ADMIN_PASSWORD} -dir ${CONTAINER_DASHBOARD_DIRECTORY}
+	@docker run --rm -it --user $(shell id -u):$(shell id -u) --mount type=bind,source=$$PWD/${LOCAL_DASHBOARD_DIRECTORY},target=${CONTAINER_DASHBOARD_DIRECTORY}/LocalDev --network="host" --user $$id:1000 --name ${GRAFANA_SYNC_DOCKER_NAME} mintel/grafana-local-sync:latest -user admin -pass ${GRAFANA_ADMIN_PASSWORD} -dir ${CONTAINER_DASHBOARD_DIRECTORY}
 	@$(MAKE) grafana/cleanup

--- a/modules/grafana/Makefile
+++ b/modules/grafana/Makefile
@@ -84,7 +84,6 @@ grafana/setup-local-grafana-oss:
 	@docker run --rm -d -p 3000:3000 --name ${GRAFANA_LOCAL_DOCKER_NAME} $(GRAFANA_IMAGE)
 
 grafana/setup-grafana-syncer:
-	@set -x;
 ifeq (${CREATE_GRAFANA_INSTANCE}, true)
 # Give the grafana instance time to start up before changing the admin password in order to avoid errors
 	@echo "Starting grafana on localhost:3000 ..."


### PR DESCRIPTION
Fixes permission issues. The user-id passed in was blank previously (or not set at all in the case of the syncer).