### PR TITLE
INFRA-39812: Migrate satoshi update targets to new naming convention.

### DIFF
--- a/modules/satoshi/Makefile
+++ b/modules/satoshi/Makefile
@@ -6,7 +6,8 @@ S_BLD := $(shell tput bold 2> /dev/null || true)
 
 REQUIRED_SATOSHI_BINS := conftest helm jb jsonnet kubectl kustomize opa pluto tk yq mimirtool
 
-.PHONY: satoshi/check-deps satoshi/check-mise-dep satoshi/update-makefile satoshi/update-tools
+.PHONY: satoshi/check-deps satoshi/check-mise-dep \
+       satoshi/update-makefile satoshi/update-tools
 
 # Skip checks if running in CI for now (binaries not installed by mise)
 ifndef CI
@@ -27,26 +28,36 @@ satoshi/check-mise-dep:
 	fi
 endif
 
-## Update Satoshi Makefile for k8s toolset
-satoshi/update-makefile:
-	@make satoshi/update-makefile/k8s
-
 ## Update Satoshi Makefile for a particular toolset e.g. k8s and tf
-satoshi/update-makefile/%: FORCE
+satoshi/makefile/update/%: FORCE
 	$(shell curl -sSL -o Makefile "https://raw.githubusercontent.com/mintel/build-harness-extensions/main/modules/satoshi/${*}-makefile.template")
 
-## Update Satoshi .tool-versions for k8s toolset
-satoshi/update-tools:
-	@make satoshi/update-tools/k8s
-
 ## Update Satoshi .tool-versions for a particular toolset e.g. k8s and tf
-satoshi/update-tools/%: FORCE
+satoshi/tools/update/%: FORCE
 	$(shell curl -sSL -o .tool-versions "https://raw.githubusercontent.com/mintel/build-harness-extensions/main/modules/satoshi/${*}-tool-versions")
-	@make mise/install
 
-## Update Satoshi asdf .tool-versions for k8s toolset and install with asdf
+## Update Satoshi mise.tool-versions for k8s toolset and install with mise
 satoshi/tools/install: FORCE
-	$(shell curl -sSL -o .tool-versions "https://raw.githubusercontent.com/mintel/build-harness-extensions/main/modules/satoshi/k8s-tool-versions")
-	@make mise/install
+	@$(MAKE) mise/install
+
+## DEPRECATED: Use satoshi/makefile/update/k8s instead
+satoshi/update-makefile:
+	@echo "$(S_YLW)$(S_BLD)[DEPRECATED] satoshi/update-makefile is deprecated, use satoshi/makefile/update/k8s instead$(S_RST)" >&2
+	@$(MAKE) satoshi/makefile/update/k8s
+
+## DEPRECATED: Use satoshi/makefile/update/<toolset> instead
+satoshi/update-makefile/%: FORCE
+	@echo "$(S_YLW)$(S_BLD)[DEPRECATED] satoshi/update-makefile/$* is deprecated, use satoshi/makefile/update/$* instead$(S_RST)" >&2
+	@$(MAKE) satoshi/makefile/update/$*
+
+## DEPRECATED: Use satoshi/tools/update/k8s instead
+satoshi/update-tools:
+	@echo "$(S_YLW)$(S_BLD)[DEPRECATED] satoshi/update-tools is deprecated, use satoshi/tools/update/k8s instead$(S_RST)" >&2
+	@$(MAKE) satoshi/tools/update/k8s
+
+## DEPRECATED: Use satoshi/tools/update/<toolset> instead
+satoshi/update-tools/%: FORCE
+	@echo "$(S_YLW)$(S_BLD)[DEPRECATED] satoshi/update-tools/$* is deprecated, use satoshi/tools/update/$* instead$(S_RST)" >&2
+	@$(MAKE) satoshi/tools/update/$*
 
 FORCE:

--- a/modules/satoshi/k8s-makefile.template
+++ b/modules/satoshi/k8s-makefile.template
@@ -1,5 +1,5 @@
 #
-# DO NOT OVERRIDE THIS FILE. AUTO-GENERATED FROM 'make satoshi/update-makefile'
+# DO NOT OVERRIDE THIS FILE. AUTO-GENERATED FROM 'make satoshi/makefile/update/k8s'
 #
 export HELP_FILTER ?= mise|grafana|jsonnet|k8s|kyverno|opa|pluto|satoshi|updater
 -include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)
@@ -17,7 +17,6 @@ bootstrap:
 ## Install tools and initial jsonnet-deps
 .PHONY: install
 install:
-      make satoshi/update-tools/k8s; \
-      make satoshi/tools/install
-      make jsonnet/install
-      exit 0
+	make satoshi/tools/update/k8s
+	make satoshi/tools/install
+	make jsonnet/install

--- a/modules/satoshi/k8s-makefile.template
+++ b/modules/satoshi/k8s-makefile.template
@@ -17,10 +17,7 @@ bootstrap:
 ## Install tools and initial jsonnet-deps
 .PHONY: install
 install:
-	@if [ ! -f .tool-versions ]; then \
-		make satoshi/update-tools/k8s; \
-	else \
-		make mise/install; \
-	fi
-	make jsonnet/install
-	exit 0
+      make satoshi/update-tools/k8s; \
+      make satoshi/tools/install
+      make jsonnet/install
+      exit 0

--- a/modules/satoshi/packer-makefile.template
+++ b/modules/satoshi/packer-makefile.template
@@ -1,5 +1,5 @@
 #
-# DO NOT OVERRIDE THIS FILE. AUTO-GENERATED FROM 'make satoshi/update-makefile/packer'
+# DO NOT OVERRIDE THIS FILE. AUTO-GENERATED FROM 'make satoshi/makefile/update/packer'
 #
 export HELP_FILTER ?= asdf|opa|packer|satoshi|updater
 -include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)

--- a/modules/satoshi/tf-makefile.template
+++ b/modules/satoshi/tf-makefile.template
@@ -19,5 +19,5 @@ bootstrap:
 ## Install tools
 .PHONY: install
 install:
-	make mise/install
+	make satoshi/tools/install
 	exit 0

--- a/modules/satoshi/tf-makefile.template
+++ b/modules/satoshi/tf-makefile.template
@@ -1,5 +1,5 @@
 #
-# DO NOT OVERRIDE THIS FILE. AUTO-GENERATED FROM 'make satoshi/update-makefile/tf'
+# DO NOT OVERRIDE THIS FILE. AUTO-GENERATED FROM 'make satoshi/makefile/update/tf'
 #
 export HELP_FILTER ?= mise|satoshi
 -include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)


### PR DESCRIPTION
I've made the makefile and tooling targets a little more consistent - or at least more aligned with how we intended them to be in the first place (i.e. better grouping).

Also, I've removed the defaults to k8s (since we now use this for other things like terraform/packer).

- Renamed `satoshi/update-makefile` and `satoshi/update-tools` targets to `satoshi/makefile/update/%` and `satoshi/tools/update/%` respectively, removing the implicit k8s default from the new targets.

- Old targets are preserved as deprecated wrappers that emit a warning and delegate to the new equivalents with an explicit /k8s suffix.

Update root Makefile install target to use the new target names and restore the jsonnet/install step that was previously regressed.