### PR TITLE
Add mcp-grafana sidecar to grafana/develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ export BUILD_HARNESS_EXTENSIONS_PATH ?= $(BUILD_HARNESS_PATH)/build-harness-exte
   grafana/cleanup                     Cleanup docker containers and files associated with grafana/develop
   grafana/develop                     Develop grafana dashboards using live datasources. Mintel internal use only.
   grafana/develop-oss                 Develop grafana dashboards without setting up datasources.
+  grafana/setup-grafana-mcp           Run grafana/mcp-grafana as a sidecar so LLM agents can drive the local Grafana instance.
   jsonnet/diff                        Diff Jsonnet fils against expected golden
   jsonnet/diff-help                   Help regarding Jsonnet diff
   jsonnet/gen-golden                  Generate expected golden files from Jsonnet

--- a/modules/grafana/Makefile
+++ b/modules/grafana/Makefile
@@ -3,12 +3,16 @@ GRAFANA_ADMIN_PASSWORD ?= admin
 LOCAL_DASHBOARD_DIRECTORY ?= $(shell ${BUILD_HARNESS_EXTENSIONS_PATH}/modules/grafana/scripts/local_dashboard_directory_prompt.sh)
 CORE_CLUSTER_JSONNET_BRANCH ?= main
 CREATE_GRAFANA_INSTANCE ?= true
+CREATE_GRAFANA_MCP ?= true
 GRAFANA_IMAGE ?= grafana/grafana:12.3.1
 GRAFANA_PLUGINS ?= natel-discrete-panel,grafana-piechart-panel,grafana-athena-datasource,marcusolsson-json-datasource,yesoreyeram-infinity-datasource
+MCP_GRAFANA_IMAGE ?= mcp/grafana:latest
+MCP_GRAFANA_PORT ?= 3001
 MINTEL_BASE_URL ?= mintel.cloud
 # Generally no reason to change these defaults, but values don't matter as long as they're different from eachother
 GRAFANA_LOCAL_DOCKER_NAME = grafana_local
 GRAFANA_SYNC_DOCKER_NAME = grafana_sync
+GRAFANA_MCP_DOCKER_NAME = grafana_mcp
 
 # Don't change these, unless you understand how they're used in the scripts below and accept the repurcussions
 CONTAINER_DASHBOARD_DIRECTORY = /app/dashboards
@@ -21,23 +25,25 @@ TMP_GRAFANA_DATASOURCES = /tmp/grafana-datasources.yaml
 
 UID=$(shell id -u)
 
-.PHONY: grafana/develop grafana/develop-oss grafana/cleanup grafana/aws-profile-check grafana/monitoring-cluster-jsonnet grafana/setup-local-grafana-mintel grafana/setup-local-grafana-oss grafana/setup-grafana-syncer
+.PHONY: grafana/develop grafana/develop-oss grafana/cleanup grafana/aws-profile-check grafana/monitoring-cluster-jsonnet grafana/setup-local-grafana-mintel grafana/setup-local-grafana-oss grafana/wait-for-grafana grafana/setup-grafana-mcp grafana/setup-grafana-syncer
 
 ifeq (${CREATE_GRAFANA_INSTANCE}, true)
 ## Develop grafana dashboards using live datasources. Mintel internal use only.
-grafana/develop: grafana/cleanup grafana/setup-local-grafana-mintel grafana/setup-grafana-syncer
+grafana/develop: grafana/cleanup grafana/setup-local-grafana-mintel grafana/setup-grafana-mcp grafana/setup-grafana-syncer
 ## Develop grafana dashboards without setting up datasources.
-grafana/develop-oss: grafana/cleanup grafana/setup-local-grafana-oss grafana/setup-grafana-syncer
+grafana/develop-oss: grafana/cleanup grafana/setup-local-grafana-oss grafana/setup-grafana-mcp grafana/setup-grafana-syncer
 else
 ## Set the CREATE_GRAFANA_INSTANCE variable to false if you already have a localhost:3000 grafana instance and just want to run the syncer
-grafana/develop: grafana/setup-grafana-syncer
-grafana/develop-oss: grafana/setup-grafana-syncer
+grafana/develop: grafana/setup-grafana-mcp grafana/setup-grafana-syncer
+grafana/develop-oss: grafana/setup-grafana-mcp grafana/setup-grafana-syncer
 endif
 
 ## Cleanup docker containers and files associated with grafana/develop
 grafana/cleanup:
 	@echo "Killing ${GRAFANA_LOCAL_DOCKER_NAME}..."
 	@docker kill ${GRAFANA_LOCAL_DOCKER_NAME} || true
+	@echo "Killing ${GRAFANA_MCP_DOCKER_NAME}..."
+	@docker kill ${GRAFANA_MCP_DOCKER_NAME} || true
 	@echo "Killing ${GRAFANA_SYNC_DOCKER_NAME}..."
 	@docker kill ${GRAFANA_SYNC_DOCKER_NAME} || true
 	@echo "Removing ${TMP_GRAFANA_DATASOURCES}..."
@@ -85,7 +91,7 @@ grafana/setup-local-grafana-oss:
 	@docker pull $(GRAFANA_IMAGE)
 	@docker run --rm -d -p 3000:3000 --name ${GRAFANA_LOCAL_DOCKER_NAME} $(GRAFANA_IMAGE)
 
-grafana/setup-grafana-syncer:
+grafana/wait-for-grafana:
 ifeq (${CREATE_GRAFANA_INSTANCE}, true)
 # Give the grafana instance time to start up before changing the admin password in order to avoid errors
 	@echo "Starting grafana on localhost:3000 ..."
@@ -93,6 +99,36 @@ ifeq (${CREATE_GRAFANA_INSTANCE}, true)
 	@while ! curl -s localhost:3000/api/health > /dev/null; do sleep 0.25; done
 	@docker exec -it ${GRAFANA_LOCAL_DOCKER_NAME} grafana cli --homepath "/usr/share/grafana" admin reset-admin-password ${GRAFANA_ADMIN_PASSWORD}
 endif
+
+## Run grafana/mcp-grafana as a sidecar so LLM agents can drive the local Grafana instance.
+grafana/setup-grafana-mcp: grafana/wait-for-grafana
+ifeq (${CREATE_GRAFANA_MCP}, true)
+	@docker pull $(MCP_GRAFANA_IMAGE)
+	@docker run --rm -d \
+		--network="host" \
+		--name ${GRAFANA_MCP_DOCKER_NAME} \
+		-e GRAFANA_URL=http://localhost:3000 \
+		-e GRAFANA_USERNAME=admin \
+		-e GRAFANA_PASSWORD=${GRAFANA_ADMIN_PASSWORD} \
+		$(MCP_GRAFANA_IMAGE) -t streamable-http --address 0.0.0.0:${MCP_GRAFANA_PORT} \
+			--disable-incident \
+			--disable-influxdb \
+			--disable-alerting \
+			--disable-oncall \
+			--disable-asserts \
+			--disable-sift \
+			--disable-pyroscope \
+			--disable-clickhouse \
+			--disable-runpanelquery \
+			--disable-graphite
+	@echo ""
+	@echo "mcp-grafana is running on http://localhost:${MCP_GRAFANA_PORT}/mcp"
+	@echo "Add it to Claude Code with:"
+	@echo "  claude mcp add --transport http grafana http://localhost:${MCP_GRAFANA_PORT}/mcp"
+	@echo ""
+endif
+
+grafana/setup-grafana-syncer: grafana/wait-for-grafana
 	@docker pull mintel/grafana-local-sync:latest
 	@docker run --rm -it --user $(UID):$(UID) --mount type=bind,source=$$PWD/${LOCAL_DASHBOARD_DIRECTORY},target=${CONTAINER_DASHBOARD_DIRECTORY}/LocalDev --network="host" --name ${GRAFANA_SYNC_DOCKER_NAME} mintel/grafana-local-sync:latest -user admin -pass ${GRAFANA_ADMIN_PASSWORD} -dir ${CONTAINER_DASHBOARD_DIRECTORY}
 	@$(MAKE) grafana/cleanup


### PR DESCRIPTION
Run grafana/mcp-grafana as a third container alongside the local Grafana and dashboard syncer so LLM agents can read and edit dashboards in the running dev instance over MCP. Exposes streamable-http on :3001, authenticates as admin using the existing GRAFANA_ADMIN_PASSWORD, and is torn down by grafana/cleanup. Set CREATE_GRAFANA_MCP=false to skip.

The grafana health-check and admin-password reset are factored out of grafana/setup-grafana-syncer into grafana/wait-for-grafana so the new MCP target and the syncer can both depend on it.