### PR TITLE
Upgrade Terraform tool versions to latest

### DIFF
--- a/modules/satoshi/tf-tool-versions
+++ b/modules/satoshi/tf-tool-versions
@@ -3,29 +3,29 @@
 #
 
 #asdf:plugin add gomplate
-gomplate v3.11.8
+gomplate v5.1.0
 
 #asdf:plugin add hcl2json
-hcl2json 0.6.3
+hcl2json 0.6.9
 
 #asdf:plugin add opentofu
-opentofu 1.7.1
+opentofu 1.11.7
 
 #asdf:plugin add terraform
-terraform 1.8.1
+terraform 1.15.2
 
 #asdf:plugin add tflint
 #renovate: depName=terraform-linters/tflint
-tflint 0.50.3
+tflint 0.62.0
 
 #asdf:plugin add terraform-docs
 #renovate: depName=terraform-docs/terraform-docs
-terraform-docs 0.17.0
+terraform-docs 0.24.0
 
 #asdf:plugin add awscli
-awscli 2.15.38
+awscli 2.34.45
 
 # TODO: remove me; tfsec is deprecated; replace with trivy
 #asdf:plugin add tfsec
 #renovate: depName=aquasecurity/tfsec
-tfsec 1.28.5
+tfsec 1.28.14


### PR DESCRIPTION
Primarily because I want Terraform >= v1.9 to support inter-variable
validation blocks, but why not upgrade everything?