### PR TITLE
Remove tfsec from Terraform tools

### DIFF
--- a/modules/satoshi/tf-pre-commit-config.yaml.template
+++ b/modules/satoshi/tf-pre-commit-config.yaml.template
@@ -29,6 +29,3 @@ repos:
         args:
           - --args=--config=.terraform-docs.yml
       - id: terraform_tflint
-      # NOTE: tfsec is deprecated upstream (replaced by terraform_trivy);
-      # tracked for removal alongside the tfsec entry in tf-tool-versions.
-      - id: terraform_tfsec

--- a/modules/satoshi/tf-tool-versions
+++ b/modules/satoshi/tf-tool-versions
@@ -25,11 +25,6 @@ terraform-docs 0.24.0
 #asdf:plugin add awscli
 awscli 2.34.45
 
-# TODO: remove me; tfsec is deprecated; replace with trivy
-#asdf:plugin add tfsec
-#renovate: depName=aquasecurity/tfsec
-tfsec 1.28.14
-
 #asdf:plugin add pre-commit
 #renovate: depName=pre-commit/pre-commit
 pre-commit 4.6.0


### PR DESCRIPTION
TFSec is long deprecated. Long enough that it doesn't recognize terraform `import {}` blocks, which is breaking some pipelines.