### PR TITLE
Make bootstrap idempotent for build-harness-extensions submodule

### DIFF
--- a/modules/satoshi/k8s-makefile.template
+++ b/modules/satoshi/k8s-makefile.template
@@ -10,8 +10,13 @@ export BUILD_HARNESS_EXTENSIONS_PATH ?= $(BUILD_HARNESS_PATH)/build-harness-exte
 .PHONY: bootstrap
 bootstrap:
 	make init
-	if [ ! -d "./build-harness-extensions" ]; then git submodule add https://github.com/mintel/build-harness-extensions.git build-harness-extensions ; fi
-	git submodule update --init --recursive
+	@if [ -d "./build-harness-extensions" ]; then \
+		: ; \
+	elif [ -f .gitmodules ] && git config --file .gitmodules --get submodule.build-harness-extensions.url >/dev/null 2>&1; then \
+		git submodule update --init --recursive build-harness-extensions ; \
+	else \
+		git submodule add https://github.com/mintel/build-harness-extensions.git build-harness-extensions ; \
+	fi
 	exit 0
 
 ## Install tools and initial jsonnet-deps

--- a/modules/satoshi/packer-makefile.template
+++ b/modules/satoshi/packer-makefile.template
@@ -10,8 +10,13 @@ export BUILD_HARNESS_EXTENSIONS_PATH ?= $(BUILD_HARNESS_PATH)/build-harness-exte
 .PHONY: bootstrap
 bootstrap:
 	make init
-	if [ ! -d "./build-harness-extensions" ]; then git submodule add https://github.com/mintel/build-harness-extensions.git build-harness-extensions ; fi
-	git submodule update --init --recursive
+	@if [ -d "./build-harness-extensions" ]; then \
+		: ; \
+	elif [ -f .gitmodules ] && git config --file .gitmodules --get submodule.build-harness-extensions.url >/dev/null 2>&1; then \
+		git submodule update --init --recursive build-harness-extensions ; \
+	else \
+		git submodule add https://github.com/mintel/build-harness-extensions.git build-harness-extensions ; \
+	fi
 	exit 0
 
 ## Install tools

--- a/modules/satoshi/tf-makefile.template
+++ b/modules/satoshi/tf-makefile.template
@@ -12,8 +12,13 @@ export BUILD_HARNESS_EXTENSIONS_PATH ?= $(BUILD_HARNESS_PATH)/build-harness-exte
 bootstrap:
 	git init
 	make init
-	if [ ! -d "./build-harness-extensions" ]; then git submodule add https://github.com/mintel/build-harness-extensions.git build-harness-extensions ; fi
-	git submodule update --init --recursive
+	@if [ -d "./build-harness-extensions" ]; then \
+		: ; \
+	elif [ -f .gitmodules ] && git config --file .gitmodules --get submodule.build-harness-extensions.url >/dev/null 2>&1; then \
+		git submodule update --init --recursive build-harness-extensions ; \
+	else \
+		git submodule add https://github.com/mintel/build-harness-extensions.git build-harness-extensions ; \
+	fi
 	exit 0
 
 ## Install tools


### PR DESCRIPTION
The previous bootstrap recipe unconditionally ran
`git submodule update --init --recursive`, which resets the build-harness-extensions submodule working tree to the parent's recorded gitlink. In Renovate runs that update the BHE digest in-place but haven't yet staged the new gitlink, this reverts the submodule to the pre-update SHA — causing rendering steps to use stale templates or fail outright, and producing MRs where rendered files and the submodule pointer drift apart.

The new recipe is a three-branch conditional:

- If `./build-harness-extensions` already exists, do nothing (preserves whatever's checked out, including Renovate's in-place updates).
- Else if `.gitmodules` already registers the submodule, hydrate the working tree at the recorded gitlink via `git submodule update --init --recursive build-harness-extensions`. This is the normal fresh-checkout case (CI runner, new clone).
- Else, run `git submodule add ...` to do one-time registration in a brand-new repo.

Applied identically to the tf, k8s, and packer satoshi makefile templates.