### PR TITLE
Detect hydrated submodule via .git, not just dir presence

### DIFF
--- a/modules/satoshi/k8s-makefile.template
+++ b/modules/satoshi/k8s-makefile.template
@@ -10,7 +10,7 @@ export BUILD_HARNESS_EXTENSIONS_PATH ?= $(BUILD_HARNESS_PATH)/build-harness-exte
 .PHONY: bootstrap
 bootstrap:
 	make init
-	@if [ -d "./build-harness-extensions" ]; then \
+	@if [ -e "./build-harness-extensions/.git" ]; then \
 		: ; \
 	elif [ -f .gitmodules ] && git config --file .gitmodules --get submodule.build-harness-extensions.url >/dev/null 2>&1; then \
 		git submodule update --init --recursive build-harness-extensions ; \

--- a/modules/satoshi/packer-makefile.template
+++ b/modules/satoshi/packer-makefile.template
@@ -10,7 +10,7 @@ export BUILD_HARNESS_EXTENSIONS_PATH ?= $(BUILD_HARNESS_PATH)/build-harness-exte
 .PHONY: bootstrap
 bootstrap:
 	make init
-	@if [ -d "./build-harness-extensions" ]; then \
+	@if [ -e "./build-harness-extensions/.git" ]; then \
 		: ; \
 	elif [ -f .gitmodules ] && git config --file .gitmodules --get submodule.build-harness-extensions.url >/dev/null 2>&1; then \
 		git submodule update --init --recursive build-harness-extensions ; \

--- a/modules/satoshi/tf-makefile.template
+++ b/modules/satoshi/tf-makefile.template
@@ -12,7 +12,7 @@ export BUILD_HARNESS_EXTENSIONS_PATH ?= $(BUILD_HARNESS_PATH)/build-harness-exte
 bootstrap:
 	git init
 	make init
-	@if [ -d "./build-harness-extensions" ]; then \
+	@if [ -e "./build-harness-extensions/.git" ]; then \
 		: ; \
 	elif [ -f .gitmodules ] && git config --file .gitmodules --get submodule.build-harness-extensions.url >/dev/null 2>&1; then \
 		git submodule update --init --recursive build-harness-extensions ; \


### PR DESCRIPTION
`git clone --no-recurse-submodules` (and GitLab CI's "Skipping Git submodules setup") creates an empty placeholder directory at the submodule path. The previous `[ -d "./build-harness-extensions" ]` check treated that empty placeholder as already-hydrated and fired the no-op branch, leaving the submodule contents missing and breaking `make install` (No rule to make target 'satoshi/tools/install').

Check for the `.git` entry inside the submodule instead — that's only present when the submodule has actually been initialized, regardless of how (clone --recurse-submodules, submodule update --init, or submodule add).