### PR TITLE
Exclude dot-prefixed directories from terraform_tflint

### DIFF
--- a/modules/satoshi/tf-pre-commit-config.yaml.template
+++ b/modules/satoshi/tf-pre-commit-config.yaml.template
@@ -29,3 +29,4 @@ repos:
         args:
           - --args=--config=.terraform-docs.yml
       - id: terraform_tflint
+        exclude: '(^|/)\.[^/]+/'


### PR DESCRIPTION
Files under hidden directories (e.g. `.config/`, `.cache/`, `.template`) were being linted by tflint, producing spurious failures. The new exclude pattern skips any path containing a dot-prefixed directory segment at any depth. It replaces the upstream default exclude `(\.terraform/.*$)` but is a strict superset of it, since .terraform/ is itself a dot-prefixed directory.